### PR TITLE
feat: IntelliSense（自動補完・型チェック）機能を拡充＆READMEに対応内容を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ TextUI Designerは、YAML/JSONベースのDSLでフロントエンドUIを宣言
 - **豊富なコンポーネント**: Text, Alert, Divider, Input, Checkbox, Radio, Select, Button, Container, Form などをサポート。
 - **Tailwind CSSベースの美しいUI**: カスタムCSS不要でモダンな見た目。
 
+## 主な機能
+- ライブプレビュー（WebView）
+- JSON Schemaによる型安全なDSLバリデーション
+- **IntelliSense（自動補完・型チェック）対応**
+- 豊富なスニペット
+- ワンクリックでReact/Tailwind/Pug/HTMLへのエクスポート
+
 ## サンプルDSL（sample.tui.yml）
 
 ```yaml
@@ -144,3 +151,21 @@ MIT
 ---
 
 ご意見・ご要望はIssueまでお寄せください。
+
+## IntelliSense（自動補完・型チェック）について
+
+- `*.tui.yml`/`*.tui.json`ファイルで、コンポーネント名・プロパティ名・値の補完候補が表示されます。
+- スキーマに基づく型エラーや必須項目の未入力は赤波線で警告されます。
+- 補完候補を選択すると、説明（description）もツールチップで表示されます。
+
+### 使い方例
+```yaml
+components:
+  - Input:
+      label: ユーザー名
+      name: username
+      type: text # ← 候補がポップアップ
+      required: true # ← true/falseも補完
+```
+
+---

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -53,14 +53,17 @@
             "properties": {
               "variant": {
                 "type": "string",
-                "enum": ["h1", "h2", "h3", "p", "small", "caption"]
+                "enum": ["h1", "h2", "h3", "p", "small", "caption"],
+                "description": "テキストの見た目（見出し・段落・注釈など）を指定します。"
               },
-              "value": { "type": "string" }
+              "value": { "type": "string", "description": "表示するテキスト内容。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "テキスト（見出し・段落など）を表示するコンポーネント。\n利用可能な属性: variant, value"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "テキスト（見出し・段落など）を表示するコンポーネント。"
       },
   
       "Input": {
@@ -71,18 +74,21 @@
             "type": "object",
             "required": ["label", "name", "type"],
             "properties": {
-              "label": { "type": "string" },
-              "name": { "type": "string" },
+              "label": { "type": "string", "description": "入力欄のラベル（表示名）。" },
+              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
               "type": {
                 "type": "string",
-                "enum": ["text", "email", "password", "number", "multiline"]
+                "enum": ["text", "email", "password", "number", "multiline"],
+                "description": "入力欄の種類（テキスト・メール・パスワード・数値・複数行）。"
               },
-              "required": { "type": "boolean", "default": false }
+              "required": { "type": "boolean", "default": false, "description": "必須入力かどうか。trueで必須。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "テキスト入力用コンポーネント。\n利用可能な属性: label, name, type, required"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "テキスト入力用コンポーネント。"
       },
   
       "Button": {
@@ -96,15 +102,18 @@
               "kind": {
                 "type": "string",
                 "enum": ["primary", "secondary", "submit"],
-                "default": "primary"
+                "default": "primary",
+                "description": "ボタンの種類（主ボタン・副ボタン・送信ボタン）。"
               },
-              "label": { "type": "string" },
-              "submit": { "type": "boolean", "default": false }
+              "label": { "type": "string", "description": "ボタンに表示するテキスト。" },
+              "submit": { "type": "boolean", "default": false, "description": "フォーム送信ボタンかどうか。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "ボタンコンポーネント。\n利用可能な属性: kind, label, submit"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "ボタンコンポーネント。"
       },
   
       "Checkbox": {
@@ -115,14 +124,16 @@
             "type": "object",
             "required": ["label", "name"],
             "properties": {
-              "label": { "type": "string" },
-              "name": { "type": "string" },
-              "required": { "type": "boolean", "default": false }
+              "label": { "type": "string", "description": "チェックボックスのラベル。" },
+              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
+              "required": { "type": "boolean", "default": false, "description": "必須項目かどうか。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "チェックボックスコンポーネント。\n利用可能な属性: label, name, required"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "チェックボックスコンポーネント。"
       },
   
       "Radio": {
@@ -133,26 +144,30 @@
             "type": "object",
             "required": ["label", "name", "options"],
             "properties": {
-              "label": { "type": "string" },
-              "name": { "type": "string" },
+              "label": { "type": "string", "description": "ラジオボタンのラベル。" },
+              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
               "options": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "required": ["label", "value"],
                   "properties": {
-                    "label": { "type": "string" },
-                    "value": { "type": ["string", "number", "boolean"] }
+                    "label": { "type": "string", "description": "選択肢の表示名。" },
+                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
                   },
-                  "additionalProperties": false
+                  "additionalProperties": false,
+                  "description": "ラジオボタンの選択肢。"
                 },
-                "minItems": 1
+                "minItems": 1,
+                "description": "選択肢の配列。"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "ラジオボタンコンポーネント。\n利用可能な属性: label, name, options"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "ラジオボタンコンポーネント。"
       },
   
       "Select": {
@@ -163,27 +178,31 @@
             "type": "object",
             "required": ["label", "name", "options"],
             "properties": {
-              "label": { "type": "string" },
-              "name": { "type": "string" },
+              "label": { "type": "string", "description": "セレクトボックスのラベル。" },
+              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
               "options": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "required": ["label", "value"],
                   "properties": {
-                    "label": { "type": "string" },
-                    "value": { "type": ["string", "number", "boolean"] }
+                    "label": { "type": "string", "description": "選択肢の表示名。" },
+                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
                   },
-                  "additionalProperties": false
+                  "additionalProperties": false,
+                  "description": "セレクトボックスの選択肢。"
                 },
-                "minItems": 1
+                "minItems": 1,
+                "description": "選択肢の配列。"
               },
-              "multiple": { "type": "boolean", "default": false }
+              "multiple": { "type": "boolean", "default": false, "description": "複数選択を許可するか。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "セレクトボックスコンポーネント。\n利用可能な属性: label, name, options, multiple"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "セレクトボックスコンポーネント。"
       },
   
       "Divider": {
@@ -196,13 +215,16 @@
               "orientation": {
                 "type": "string",
                 "enum": ["horizontal", "vertical"],
-                "default": "horizontal"
+                "default": "horizontal",
+                "description": "区切り線の向き（横・縦）。"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "区切り線コンポーネント。\n利用可能な属性: orientation"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "区切り線コンポーネント。"
       },
   
       "Container": {
@@ -214,15 +236,18 @@
             "properties": {
               "layout": {
                 "type": "string",
-                "enum": ["vertical", "horizontal", "flex", "grid"]
+                "enum": ["vertical", "horizontal", "flex", "grid"],
+                "description": "子コンポーネントの配置方法。"
               },
-              "components": { "$ref": "#/definitions/componentArray" }
+              "components": { "$ref": "#/definitions/componentArray", "description": "子コンポーネントの配列。" }
             },
             "required": ["components"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "レイアウト用コンテナコンポーネント。\n利用可能な属性: layout, components"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "レイアウト用コンテナコンポーネント。"
       },
   
       "Alert": {
@@ -236,14 +261,17 @@
               "variant": {
                 "type": "string",
                 "enum": ["info", "success", "warning", "error"],
-                "default": "info"
+                "default": "info",
+                "description": "アラートの種類（情報・成功・警告・エラー）。"
               },
-              "message": { "type": "string" }
+              "message": { "type": "string", "description": "表示するメッセージ内容。" }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "アラートコンポーネント。\n利用可能な属性: variant, message"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "アラートコンポーネント。"
       },
   
       "Form": {
@@ -253,18 +281,21 @@
           "Form": {
             "type": "object",
             "properties": {
-              "id": { "type": "string" },
-              "fields": { "$ref": "#/definitions/componentArray" },
+              "id": { "type": "string", "description": "フォームのID。" },
+              "fields": { "$ref": "#/definitions/componentArray", "description": "フォーム内の入力フィールド群。" },
               "actions": {
                 "type": "array",
-                "items": { "$ref": "#/definitions/Button" }
+                "items": { "$ref": "#/definitions/Button" },
+                "description": "フォーム下部のボタン群。"
               }
             },
             "required": ["fields"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "フォームコンポーネント。\n利用可能な属性: id, fields, actions"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "フォームコンポーネント。"
       }
     },
     "additionalProperties": false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,23 @@ import Ajv from 'ajv';
 export function activate(context: vscode.ExtensionContext) {
 	let currentPanel: vscode.WebviewPanel | undefined = undefined;
 
+	// YAML/JSONスキーマ連携: *.tui.yml, *.tui.json に schema.json を紐付け
+	const schemaPath = path.join(context.extensionPath, 'schemas', 'schema.json');
+	const schemaUri = vscode.Uri.file(schemaPath).toString();
+
+	// YAML拡張（redhat.vscode-yaml）向け
+	vscode.workspace.getConfiguration('yaml').update('schemas', {
+		[schemaUri]: ['*.tui.yml']
+	}, vscode.ConfigurationTarget.Global);
+
+	// JSON拡張向け
+	vscode.workspace.getConfiguration('json').update('schemas', [
+		{
+			fileMatch: ['*.tui.json'],
+			schema: JSON.parse(fs.readFileSync(schemaPath, 'utf-8'))
+		}
+	], vscode.ConfigurationTarget.Global);
+
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "textui-designer" is now active!');
@@ -76,6 +93,127 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 			}
 		})
+	);
+
+	// --- YAML用IntelliSense: コンポーネント名補完 ---
+	const COMPONENT_NAMES = [
+		'Text', 'Input', 'Button', 'Checkbox', 'Radio', 'Select', 'Divider', 'Container', 'Alert', 'Form'
+	];
+
+	const INDENT_COMMAND = 'textui-designer.insertIndent';
+	context.subscriptions.push(
+		vscode.commands.registerCommand(INDENT_COMMAND, async () => {
+			const editor = vscode.window.activeTextEditor;
+			if (editor) {
+				await editor.edit(editBuilder => {
+					editBuilder.insert(editor.selection.active, '  ');
+				});
+			}
+		})
+	);
+
+	// --- YAML用IntelliSense: プロパティ名・値の補完 ---
+	const COMPONENT_PROPERTIES: Record<string, { props: string[]; enums?: Record<string, string[]>; booleans?: string[] }> = {
+		Text: { props: ['variant', 'value'], enums: { variant: ['h1', 'h2', 'h3', 'p', 'small', 'caption'] } },
+		Input: { props: ['label', 'name', 'type', 'required'], enums: { type: ['text', 'email', 'password', 'number', 'multiline'] }, booleans: ['required'] },
+		Button: { props: ['kind', 'label', 'submit'], enums: { kind: ['primary', 'secondary', 'submit'] }, booleans: ['submit'] },
+		Checkbox: { props: ['label', 'name', 'required'], booleans: ['required'] },
+		Radio: { props: ['label', 'name', 'options'] },
+		Select: { props: ['label', 'name', 'options', 'multiple'], booleans: ['multiple'] },
+		Divider: { props: ['orientation'], enums: { orientation: ['horizontal', 'vertical'] } },
+		Container: { props: ['layout', 'components'], enums: { layout: ['vertical', 'horizontal', 'flex', 'grid'] } },
+		Alert: { props: ['variant', 'message'], enums: { variant: ['info', 'success', 'warning', 'error'] } },
+		Form: { props: ['id', 'fields', 'actions'] },
+	};
+
+	context.subscriptions.push(
+		vscode.languages.registerCompletionItemProvider(
+			{ language: 'yaml', pattern: '**/*.tui.yml' },
+			{
+				provideCompletionItems(document, position) {
+					const line = document.lineAt(position.line).text;
+					const currIndent = line.match(/^\s*/)?.[0].length ?? 0;
+
+					// 上方向に探索して、1段浅い行がコンポーネント名ならプロパティ補完
+					for (let i = position.line - 1; i >= 0; i--) {
+						const prev = document.lineAt(i).text;
+						const prevIndent = prev.match(/^\s*/)?.[0].length ?? 0;
+						if (prevIndent < currIndent) {
+							const compMatch = prev.match(/^[ \t]*([A-Za-z]+):/);
+							if (compMatch) {
+								const comp = compMatch[1];
+								const def = COMPONENT_PROPERTIES[comp];
+								if (def) {
+									return def.props.map(prop => {
+										const item = new vscode.CompletionItem(prop, vscode.CompletionItemKind.Property);
+										item.detail = `${comp}のプロパティ`;
+										item.insertText = prop + ': ';
+										return item;
+									});
+								}
+							}
+							break;
+						}
+					}
+
+					// 上方向に探索して、2段浅い行がコンポーネント名、1段浅い行がプロパティ名なら値補完
+					for (let i = position.line - 1; i >= 1; i--) {
+						const prev = document.lineAt(i).text;
+						const prevIndent = prev.match(/^\s*/)?.[0].length ?? 0;
+						if (prevIndent < currIndent) {
+							const propMatch = prev.match(/^[ \t]*([a-zA-Z0-9_]+):/);
+							if (propMatch) {
+								const prop = propMatch[1];
+								for (let j = i - 1; j >= 0; j--) {
+									const compLine = document.lineAt(j).text;
+									const compIndent = compLine.match(/^\s*/)?.[0].length ?? 0;
+									if (compIndent < prevIndent) {
+										const compMatch = compLine.match(/^[ \t]*([A-Za-z]+):/);
+										if (compMatch) {
+											const comp = compMatch[1];
+											const def = COMPONENT_PROPERTIES[comp];
+											if (def) {
+												if (def.enums && def.enums[prop]) {
+													return def.enums[prop].map(val => {
+														const item = new vscode.CompletionItem(val, vscode.CompletionItemKind.EnumMember);
+														item.detail = `${comp}.${prop}の候補値`;
+														item.insertText = val;
+														return item;
+													});
+												}
+												if (def.booleans && def.booleans.includes(prop)) {
+													return ['true', 'false'].map(val => {
+														const item = new vscode.CompletionItem(val, vscode.CompletionItemKind.Value);
+														item.detail = `${comp}.${prop}の真偽値`;
+														item.insertText = val;
+														return item;
+													});
+												}
+											}
+										}
+										break;
+									}
+								}
+							}
+							break;
+						}
+					}
+
+					// 既存のコンポーネント名補完
+					if (/^\s*-\s*$/.test(line)) {
+						return COMPONENT_NAMES.map(name => {
+							const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Class);
+							item.detail = 'TextUIコンポーネント';
+							item.insertText = ` ${name}: `;
+							item.command = { command: INDENT_COMMAND, title: 'インデントを挿入' };
+							return item;
+						});
+					}
+					return undefined;
+				}
+			},
+			'-', ':' // トリガー文字: ハイフン・コロン
+		)
 	);
 }
 

--- a/src/renderer/components/Input.tsx
+++ b/src/renderer/components/Input.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
-
-type InputType = 'text' | 'email' | 'password' | 'number';
+import type { InputType } from '../types';
 
 interface InputProps {
   label: string;
   name: string;
   type: InputType;
   required?: boolean;
-  multiline?: boolean;
 }
 
 export const Input: React.FC<InputProps> = ({
   label,
   name,
   type,
-  required = false,
-  multiline = false,
+  required = false
 }) => {
   const inputClasses = 'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500';
 
@@ -25,7 +22,7 @@ export const Input: React.FC<InputProps> = ({
         {label}
         {required && <span className="text-red-500 ml-1">*</span>}
       </label>
-      {multiline ? (
+      {type === 'multiline' ? (
         <textarea
           id={name}
           name={name}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -7,7 +7,7 @@ export interface TextComponent {
   value: string;
 }
 
-export type InputType = 'text' | 'email' | 'password' | 'number';
+export type InputType = 'text' | 'email' | 'password' | 'number' | 'multiline';
 
 export interface InputComponent {
   label: string;


### PR DESCRIPTION
- YAML/JSON DSLでコンポーネント名・プロパティ名・値の補完に対応
- enum値やboolean値も補完候補として表示
- インデント・階層を考慮した補完ロジックに改善
- スキーマdescriptionも属性一覧付きで充実
- READMEに「IntelliSense対応」機能説明と使い方例を追加

fix: レンダリング不具合を修正

- Inputのmultiline設定時にtextareaとして表示できなかった問題に対応