### PR TITLE
feat: スニペット機能の追加＆READMEに使い方・一覧を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ TextUI Designerは、YAML/JSONベースのDSLでフロントエンドUIを宣言
 - ライブプレビュー（WebView）
 - JSON Schemaによる型安全なDSLバリデーション
 - **IntelliSense（自動補完・型チェック）対応**
-- 豊富なスニペット
+- **エラー箇所のハイライト（赤波線）**
+- **スニペット入力補助（tui:form など）対応**
 - ワンクリックでReact/Tailwind/Pug/HTMLへのエクスポート
 
 ## サンプルDSL（sample.tui.yml）
@@ -137,20 +138,7 @@ page:
 - Container（horizontal, vertical, flex, grid）
 - Form
 
-## 必要要件
-- VS Code 1.80以上
-- Node.js 16以上（開発・ビルド時）
-
-## 既知の問題
-- スキーマや型定義の変更時は、拡張機能の再読み込みが必要な場合があります。
-- 一部の複雑なレイアウトやカスタムCSSには未対応です。
-
-## ライセンス
-MIT
-
 ---
-
-ご意見・ご要望はIssueまでお寄せください。
 
 ## IntelliSense（自動補完・型チェック）について
 
@@ -169,3 +157,50 @@ components:
 ```
 
 ---
+
+## スニペット機能について
+
+主要なTextUIコンポーネントのテンプレートを、Tab補完やコマンドパレットから素早く挿入できます。
+
+- `tui:form` … フォーム一式のテンプレート
+- `tui:input` … 入力欄のテンプレート
+- `tui:container` … レイアウト用コンテナのテンプレート
+- `tui:alert` … アラートのテンプレート
+
+### 使い方
+1. `*.tui.yml` または `*.tui.json` ファイルで、`tui:form` などと入力
+2. Tabキーや補完候補から選択すると、テンプレートが展開されます
+3. `$1`, `$2` などの変数位置にカーソル移動しながら編集できます
+
+### 例（tui:form）
+```yaml
+- Form:
+    id: myForm
+    fields:
+      - Input:
+          label: ユーザー名
+          name: username
+          type: text
+    actions:
+      - Button:
+          kind: primary
+          label: 送信
+          submit: true
+```
+
+---
+
+## 必要要件
+- VS Code 1.80以上
+- Node.js 16以上（開発・ビルド時）
+
+## 既知の問題
+- スキーマや型定義の変更時は、拡張機能の再読み込みが必要な場合があります。
+- 一部の複雑なレイアウトやカスタムCSSには未対応です。
+
+## ライセンス
+MIT
+
+---
+
+ご意見・ご要望はIssueまでお寄せください。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,17 @@
           "group": "navigation"
         }
       ]
-    }
+    },
+    "snippets": [
+      {
+        "language": "yaml",
+        "path": "./snippets/tui-snippets.json"
+      },
+      {
+        "language": "json",
+        "path": "./snippets/tui-snippets.json"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/snippets/tui-snippets.json
+++ b/snippets/tui-snippets.json
@@ -1,0 +1,49 @@
+{
+  "tui:form": {
+    "prefix": "tui:form",
+    "body": [
+      "- Form:",
+      "    id: $1",
+      "    fields:",
+      "      - Input:",
+      "          label: $2",
+      "          name: $3",
+      "          type: ${4|text,email,password,number,multiline|}",
+      "    actions:",
+      "      - Button:",
+      "          kind: primary",
+      "          label: $5",
+      "          submit: true"
+    ],
+    "description": "フォームのテンプレート"
+  },
+  "tui:input": {
+    "prefix": "tui:input",
+    "body": [
+      "- Input:",
+      "    label: $1",
+      "    name: $2",
+      "    type: ${3|text,email,password,number,multiline|}",
+      "    required: ${4|true,false|}"
+    ],
+    "description": "入力欄のテンプレート"
+  },
+  "tui:container": {
+    "prefix": "tui:container",
+    "body": [
+      "- Container:",
+      "    layout: ${1|vertical,horizontal,flex,grid|}",
+      "    components: "
+    ],
+    "description": "レイアウト用コンテナのテンプレート"
+  },
+  "tui:alert": {
+    "prefix": "tui:alert",
+    "body": [
+      "- Alert:",
+      "    variant: ${1|info,success,warning,error|}",
+      "    message: $2"
+    ],
+    "description": "アラートのテンプレート"
+  }
+} 


### PR DESCRIPTION
- tui:form, tui:input, tui:container, tui:alert など主要コンポーネントのスニペットを追加
- YAML/JSON両対応でTab補完・コマンドパレットから素早く挿入可能
- 変数や選択肢を活用し、編集しやすいテンプレートを提供
- READMEにスニペット機能の説明・使い方・一覧・展開例を追加