### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ export function activate(context: vscode.ExtensionContext) {
 				for (const err of validate.errors) {
 					const key = err.instancePath.split('/').filter(Boolean).pop();
 					if (key) {
-						const regex = new RegExp(`^\s*${key}:`, 'm');
+						const regex = new RegExp(`^\\s*${key}:`, 'm');
 						const match = text.match(regex);
 						if (match) {
 							const start = text.indexOf(match[0]);


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/1](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/1)

To fix the issue, the `\s` escape sequence in the string literal should be properly escaped as `\\s`. This ensures that the backslash is preserved when the string is interpreted, and the resulting regular expression correctly matches whitespace. The same applies to any other escape sequences in the string literal that are intended to be part of the regular expression.

Specifically, the line:
```ts
const regex = new RegExp(`^\s*${key}:`, 'm');
```
should be updated to:
```ts
const regex = new RegExp(`^\\s*${key}:`, 'm');
```

This change ensures that the regular expression behaves as intended, matching lines that start with optional whitespace followed by the specified key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
