### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,7 +140,7 @@ export function activate(context: vscode.ExtensionContext) {
 				for (const err of validate.errors) {
 					const key = err.instancePath.split('/').filter(Boolean).pop();
 					if (key) {
-						const regex = new RegExp(`^\s*${key}:`, 'm');
+						const regex = new RegExp(`^\\s*${key}:`, 'm');
 						const match = text.match(regex);
 						if (match) {
 							const start = text.indexOf(match[0]);


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/1](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/1)

To fix the issue, the regular expression should be correctly escaped to ensure that `\s` is interpreted as "whitespace" in the context of a regular expression. This can be achieved by doubling the backslashes (`\\s`) in the string literal, so that the `RegExp` constructor receives the correct pattern.

Specifically, the line:
```ts
const regex = new RegExp(`^\s*${key}:`, 'm');
```
should be updated to:
```ts
const regex = new RegExp(`^\\s*${key}:`, 'm');
```

This ensures that the `\s` escape sequence is correctly passed to the `RegExp` constructor as part of the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
