### PR TITLE
Implement theme design tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,8 @@
     ],
     "yaml.schemas": {
       "./schemas/schema.json": ["*.tui.yml", "*.tui.yaml"],
-      "./schemas/template-schema.json": ["*.template.yml", "*.template.yaml"]
+      "./schemas/template-schema.json": ["*.template.yml", "*.template.yaml"],
+      "./schemas/theme-schema.json": ["textui-theme.yml", "textui-theme.yaml"]
     }
   },
   "scripts": {

--- a/schemas/theme-schema.json
+++ b/schemas/theme-schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/textui/theme-schema.json",
+  "title": "TextUI Theme Schema",
+  "type": "object",
+  "properties": {
+    "theme": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "tokens": {
+          "type": "object",
+          "properties": {
+            "color": { "type": "object" },
+            "spacing": { "type": "object" },
+            "typography": { "type": "object" },
+            "borderRadius": { "type": "object" },
+            "shadow": { "type": "object" }
+          },
+          "additionalProperties": true
+        },
+        "components": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "required": ["tokens"],
+      "additionalProperties": true
+    }
+  },
+  "required": ["theme"],
+  "additionalProperties": false
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,11 @@ import { ExportManager } from './exporters';
 import { ErrorHandler } from './utils/error-handler';
 import { ConfigManager } from './utils/config-manager';
 import { PerformanceMonitor } from './utils/performance-monitor';
+import { ThemeManager } from './services/theme-manager';
 
 // グローバル変数としてSchemaManagerを保存
 let globalSchemaManager: SchemaManager | undefined;
+let themeManagerInstance: ThemeManager | undefined;
 
 /**
  * サポートされているファイルかチェック
@@ -47,6 +49,8 @@ export function activate(context: vscode.ExtensionContext) {
   globalSchemaManager = schemaManager; // グローバルに保存
   
   const webViewManager = new WebViewManager(context);
+  const themeManager = new ThemeManager(context);
+  themeManagerInstance = themeManager;
   const exportManager = new ExportManager();
   const exportService = new ExportService(exportManager);
   const templateService = new TemplateService();
@@ -77,6 +81,14 @@ export function activate(context: vscode.ExtensionContext) {
 
   // コマンドの登録
   commandManager.registerCommands();
+
+  // テーマ読み込み
+  themeManager.loadTheme().then(() => {
+    webViewManager.applyThemeVariables(themeManager.generateCSSVariables());
+  });
+  themeManager.watchThemeFile(css => {
+    webViewManager.applyThemeVariables(css);
+  });
 
   // 補完プロバイダーの登録
   const completionDisposable = vscode.languages.registerCompletionItemProvider(
@@ -226,6 +238,8 @@ export function deactivate() {
     });
     globalSchemaManager = undefined;
   }
+
+  themeManagerInstance?.dispose?.();
 
   console.log('TextUI Designer拡張の非アクティベーション完了');
 } 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -9,29 +9,38 @@
   --vscode-background: unset !important;
   --vscode-editor-foreground: unset !important;
   --vscode-editor-background: unset !important;
+  --color-primary: #3B82F6;
+  --color-secondary: #6B7280;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --color-surface: #1f2937;
+  --color-background: #ffffff;
+  --color-text-primary: #e5e7eb;
+  --color-text-dark: #1f2937;
 }
 
 /* ダークモード対応のカスタムスタイル */
 .textui-container {
   @apply max-w-4xl mx-auto p-6;
-  background-color: rgb(31 41 55) !important; /* ダークグレー背景 */
+  background-color: var(--color-surface) !important;
   border-radius: 0.75rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 /* ライトモード用のコンテナスタイル */
 .light .textui-container {
-  background-color: rgb(255 255 255) !important; /* 白背景 */
+  background-color: var(--color-background) !important;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 .textui-text {
-  color: rgb(243 244 246) !important; /* 明るいグレー文字 */
+  color: var(--color-text-primary) !important;
 }
 
 /* ライトモード用のテキストスタイル */
 .light .textui-text {
-  color: rgb(31 41 55) !important; /* ダークグレー文字 */
+  color: var(--color-text-dark) !important;
 }
 
 .textui-text.h1 {
@@ -107,8 +116,8 @@
 
 .textui-alert.info {
   background-color: rgba(59, 130, 246, 0.1) !important;
-  border-color: rgb(59 130 246) !important;
-  color: rgb(147 197 253) !important; /* 明るいブルー文字 */
+  border-color: var(--color-primary) !important;
+  color: var(--color-primary) !important;
 }
 
 /* ライトモード用のinfoアラート */
@@ -120,8 +129,8 @@
 
 .textui-alert.success {
   background-color: rgba(34, 197, 94, 0.1) !important;
-  border-color: rgb(34 197 94) !important;
-  color: rgb(134 239 172) !important; /* 明るいグリーン文字 */
+  border-color: var(--color-success) !important;
+  color: var(--color-success) !important;
 }
 
 /* ライトモード用のsuccessアラート */
@@ -133,8 +142,8 @@
 
 .textui-alert.warning {
   background-color: rgba(245, 158, 11, 0.1) !important;
-  border-color: rgb(245 158 11) !important;
-  color: rgb(253 230 138) !important; /* 明るいイエロー文字 */
+  border-color: var(--color-warning) !important;
+  color: var(--color-warning) !important;
 }
 
 /* ライトモード用のwarningアラート */
@@ -146,8 +155,8 @@
 
 .textui-alert.error {
   background-color: rgba(239, 68, 68, 0.1) !important;
-  border-color: rgb(239 68 68) !important;
-  color: rgb(252 165 165) !important; /* 明るいレッド文字 */
+  border-color: var(--color-error) !important;
+  color: var(--color-error) !important;
 }
 
 /* ライトモード用のerrorアラート */
@@ -244,7 +253,7 @@
 }
 
 .textui-button.primary {
-  background-color: rgb(59 130 246) !important; /* ブルー */
+  background-color: var(--color-primary) !important;
   color: rgb(255 255 255) !important;
   box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.2);
 }
@@ -256,7 +265,7 @@
 }
 
 .textui-button.secondary {
-  background-color: rgb(75 85 99) !important; /* グレー */
+  background-color: var(--color-secondary) !important;
   color: rgb(255 255 255) !important;
 }
 
@@ -275,7 +284,7 @@
 }
 
 .textui-button.submit {
-  background-color: rgb(34 197 94) !important; /* グリーン */
+  background-color: var(--color-success) !important;
   color: rgb(255 255 255) !important;
   box-shadow: 0 4px 6px -1px rgba(34, 197, 94, 0.2);
 }
@@ -323,25 +332,25 @@
 
 /* 全体的な背景色の設定 */
 body {
-  background-color: rgb(17 24 39) !important; /* ダーク背景 */
-  color: rgb(229 231 235) !important; /* 明るいグレー文字 */
+  background-color: var(--color-surface) !important;
+  color: var(--color-text-primary) !important;
 }
 
 /* ライトモード用の背景色 */
 body.light {
-  background-color: rgb(249 250 251) !important; /* ライトグレー背景 */
-  color: rgb(55 65 81) !important; /* ダークグレー文字 */
+  background-color: var(--color-background) !important;
+  color: var(--color-text-dark) !important;
 }
 
 #root {
-  background-color: rgb(17 24 39) !important; /* ダーク背景 */
+  background-color: var(--color-surface) !important;
   min-height: 100vh;
   padding: 1rem;
 }
 
 /* ライトモード用のルート背景 */
 .light #root {
-  background-color: rgb(249 250 251) !important; /* ライトグレー背景 */
+  background-color: var(--color-background) !important;
 }
 
 /* テーマ切り替えボタンのスタイル */

--- a/src/renderer/webview.tsx
+++ b/src/renderer/webview.tsx
@@ -116,6 +116,11 @@ const App: React.FC = () => {
       } else if (message.type === 'theme-change') {
         console.log('[React] テーマ変更メッセージを受信:', message.theme);
         // テーマ変更はThemeToggleコンポーネントで処理される
+      } else if (message.type === 'theme-variables') {
+        const styleEl = document.getElementById('theme-vars');
+        if (styleEl) {
+          styleEl.textContent = message.css;
+        }
       } else {
         console.log('[React] 未対応のメッセージタイプ:', message.type);
       }

--- a/src/services/theme-manager.ts
+++ b/src/services/theme-manager.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as YAML from 'yaml';
+import Ajv from 'ajv';
+
+export class ThemeManager {
+  private context: vscode.ExtensionContext;
+  private themePath: string | undefined;
+  private tokens: any = {};
+  private watcher: vscode.FileSystemWatcher | undefined;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (folder) {
+      this.themePath = path.join(folder.uri.fsPath, 'textui-theme.yml');
+    }
+  }
+
+  async loadTheme(): Promise<void> {
+    if (!this.themePath || !fs.existsSync(this.themePath)) {
+      console.log('[ThemeManager] theme file not found');
+      this.tokens = {};
+      return;
+    }
+    try {
+      const content = fs.readFileSync(this.themePath, 'utf-8');
+      const data = YAML.parse(content);
+      await this.validateTheme(data);
+      this.tokens = data.theme?.tokens || {};
+      console.log('[ThemeManager] theme loaded');
+    } catch (err) {
+      console.error('[ThemeManager] failed to load theme', err);
+      this.tokens = {};
+    }
+  }
+
+  generateCSSVariables(): string {
+    const flat = this.flattenTokens(this.tokens);
+    const lines = Object.entries(flat).map(([k, v]) => `  --${k}: ${v};`);
+    return `:root {\n${lines.join('\n')}\n}`;
+  }
+
+  private flattenTokens(obj: any, prefix = ''): Record<string, string> {
+    let result: Record<string, string> = {};
+    if (!obj) return result;
+    for (const [key, value] of Object.entries(obj)) {
+      const newKey = prefix ? `${prefix}-${key}` : key;
+      if (value && typeof value === 'object' && 'value' in (value as any)) {
+        result[newKey] = (value as any).value as string;
+      } else if (value && typeof value === 'object') {
+        Object.assign(result, this.flattenTokens(value, newKey));
+      } else {
+        result[newKey] = String(value);
+      }
+    }
+    return result;
+  }
+
+  private async validateTheme(data: any): Promise<void> {
+    try {
+      const schemaPath = path.join(this.context.extensionPath, 'schemas', 'theme-schema.json');
+      if (!fs.existsSync(schemaPath)) {
+        console.warn('[ThemeManager] theme schema not found');
+        return;
+      }
+      const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+      const ajv = new Ajv();
+      const validate = ajv.compile(schema);
+      const valid = validate(data);
+      if (!valid) {
+        console.warn('[ThemeManager] theme validation failed', validate.errors);
+      }
+    } catch (e) {
+      console.warn('[ThemeManager] validation error', e);
+    }
+  }
+
+  watchThemeFile(callback: (css: string) => void): void {
+    if (!this.themePath) return;
+    const pattern = new vscode.RelativePattern(path.dirname(this.themePath), path.basename(this.themePath));
+    this.watcher = vscode.workspace.createFileSystemWatcher(pattern);
+    const reload = async () => {
+      await this.loadTheme();
+      callback(this.generateCSSVariables());
+    };
+    this.watcher.onDidChange(reload);
+    this.watcher.onDidCreate(reload);
+    this.watcher.onDidDelete(async () => {
+      this.tokens = {};
+      callback('');
+    });
+  }
+
+  dispose(): void {
+    this.watcher?.dispose();
+  }
+}

--- a/src/services/webview-manager.ts
+++ b/src/services/webview-manager.ts
@@ -260,6 +260,19 @@ export class WebViewManager {
   }
 
   /**
+   * テーマ用CSS変数をWebViewへ送信
+   */
+  applyThemeVariables(css: string): void {
+    if (!this.currentPanel) {
+      return;
+    }
+    this.currentPanel.webview.postMessage({
+      type: 'theme-variables',
+      css
+    });
+  }
+
+  /**
    * WebViewにテーマ変更を通知
    */
   notifyThemeChange(theme: 'light' | 'dark'): void {

--- a/src/utils/webview-utils.ts
+++ b/src/utils/webview-utils.ts
@@ -25,6 +25,7 @@ export function getWebviewContent(context: vscode.ExtensionContext, panel?: vsco
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TextUI Preview</title>
   <link rel="stylesheet" href="${cssUri}">
+  <style id="theme-vars"></style>
   <style>
     /* VS Codeテーマ変数を無効化 */
     :root {


### PR DESCRIPTION
## Summary
- add new `ThemeManager` service for design tokens
- register theme schema and watcher
- support theme variables in preview webview
- expose `applyThemeVariables` from `WebViewManager`
- load theme on activation and pass CSS variables to webview
- use CSS custom properties in default styles

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails to compile TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685653ce4e84832fbad56c073982453b