### PR TITLE
Add base class for renderer components

### DIFF
--- a/src/renderer/components/Alert.tsx
+++ b/src/renderer/components/Alert.tsx
@@ -1,30 +1,38 @@
 import React from 'react';
 import { AlertComponent } from '../types';
+import { BaseComponent, type BaseComponentProps } from './BaseComponent';
 
 type AlertVariant = 'info' | 'success' | 'warning' | 'error';
 
-interface AlertProps extends AlertComponent {
+interface AlertProps extends AlertComponent, BaseComponentProps {
   variant?: AlertVariant;
   message: string;
   title?: string;
 }
 
 const variantClasses: Record<AlertVariant, string> = {
-  info: 'textui-alert info',
-  success: 'textui-alert success',
-  warning: 'textui-alert warning',
-  error: 'textui-alert error',
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
 };
 
-export const Alert: React.FC<AlertProps> = ({ 
-  variant = 'info', 
-  message,
-  title 
-}) => {
-  return (
-    <div className={variantClasses[variant]}>
-      {title && <div className="textui-alert-title">{title}</div>}
-      <div className="textui-alert-message">{message}</div>
-    </div>
-  );
-}; 
+export class Alert extends BaseComponent<AlertProps> {
+  protected defaultClassName = 'textui-alert';
+
+  render() {
+    const { variant = 'info', message, title } = this.props;
+
+    const className = [
+      this.getMergedClassName(),
+      variantClasses[variant]
+    ].join(' ');
+
+    return (
+      <div className={className}>
+        {title && <div className="textui-alert-title">{title}</div>}
+        <div className="textui-alert-message">{message}</div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/BaseComponent.tsx
+++ b/src/renderer/components/BaseComponent.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export interface BaseComponentProps {
+  id?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * TextUIコンポーネントの基底クラス
+ * 共通プロパティとクラス名結合処理を提供する
+ */
+export abstract class BaseComponent<P extends BaseComponentProps, S = {}> extends React.PureComponent<P, S> {
+  /** 各コンポーネントで使用するデフォルトクラス名 */
+  protected abstract defaultClassName: string;
+
+  /**
+   * デフォルトクラス名とprops.classNameを結合した文字列を返す
+   */
+  protected getMergedClassName(): string {
+    const { className } = this.props;
+    return [this.defaultClassName, className].filter(Boolean).join(' ');
+  }
+}

--- a/src/renderer/components/Button.tsx
+++ b/src/renderer/components/Button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { ButtonComponent } from '../types';
+import { BaseComponent, type BaseComponentProps } from './BaseComponent';
 
 type ButtonKind = 'primary' | 'secondary' | 'submit';
 
-interface ButtonProps extends ButtonComponent {
+interface ButtonProps extends ButtonComponent, BaseComponentProps {
   kind?: ButtonKind;
   label: string;
   submit?: boolean;
@@ -13,9 +14,9 @@ interface ButtonProps extends ButtonComponent {
 }
 
 const kindClasses: Record<ButtonKind, string> = {
-  primary: 'textui-button primary',
-  secondary: 'textui-button secondary',
-  submit: 'textui-button submit',
+  primary: 'primary',
+  secondary: 'secondary',
+  submit: 'submit',
 };
 
 const sizeClasses: Record<string, string> = {
@@ -24,27 +25,27 @@ const sizeClasses: Record<string, string> = {
   lg: 'px-6 py-3 text-lg',
 };
 
-export const Button: React.FC<ButtonProps> = ({
-  kind = 'primary',
-  label,
-  submit = false,
-  disabled = false,
-  size = 'md',
-  onClick,
-}) => {
-  const className = [
-    kindClasses[kind],
-    sizeClasses[size]
-  ].join(' ');
+export class Button extends BaseComponent<ButtonProps> {
+  protected defaultClassName = 'textui-button';
 
-  return (
-    <button
-      type={submit ? 'submit' : 'button'}
-      className={className}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      {label}
-    </button>
-  );
-}; 
+  render() {
+    const { kind = 'primary', label, submit = false, disabled = false, size = 'md', onClick } = this.props;
+
+    const className = [
+      this.getMergedClassName(),
+      kindClasses[kind],
+      sizeClasses[size]
+    ].join(' ');
+
+    return (
+      <button
+        type={submit ? 'submit' : 'button'}
+        className={className}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {label}
+      </button>
+    );
+  }
+}

--- a/src/renderer/components/Container.tsx
+++ b/src/renderer/components/Container.tsx
@@ -1,25 +1,31 @@
 import React from 'react';
 import { ContainerComponent } from '../types';
+import { BaseComponent, type BaseComponentProps } from './BaseComponent';
 
 type Layout = 'vertical' | 'horizontal' | 'flex' | 'grid';
 
-interface ContainerProps extends Omit<ContainerComponent, 'components'> {
+interface ContainerProps extends Omit<ContainerComponent, 'components'>, BaseComponentProps {
   layout?: Layout;
   children: React.ReactNode;
 }
 
 const layoutClasses: Record<Layout, string> = {
-  vertical: 'textui-container flex flex-col space-y-4',
-  horizontal: 'textui-container flex flex-row space-x-4',
-  flex: 'textui-container flex flex-wrap gap-4',
-  grid: 'textui-container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4',
+  vertical: 'flex flex-col space-y-4',
+  horizontal: 'flex flex-row space-x-4',
+  flex: 'flex flex-wrap gap-4',
+  grid: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4',
 };
 
-export const Container: React.FC<ContainerProps> = ({ 
-  layout = 'vertical', 
-  children 
-}) => {
-  const className = layoutClasses[layout];
+export class Container extends BaseComponent<ContainerProps> {
+  protected defaultClassName = 'textui-container';
 
-  return <div className={className}>{children}</div>;
-}; 
+  render() {
+    const { layout = 'vertical', children } = this.props;
+    const className = [
+      this.getMergedClassName(),
+      layoutClasses[layout]
+    ].join(' ');
+
+    return <div className={className}>{children}</div>;
+  }
+}

--- a/src/renderer/components/Divider.tsx
+++ b/src/renderer/components/Divider.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { DividerComponent } from '../types';
+import { BaseComponent, type BaseComponentProps } from './BaseComponent';
 
-interface DividerProps extends DividerComponent {
+interface DividerProps extends DividerComponent, BaseComponentProps {
   orientation?: 'horizontal' | 'vertical';
   spacing?: 'sm' | 'md' | 'lg';
 }
@@ -12,18 +13,21 @@ const spacingClasses: Record<string, string> = {
   lg: 'my-8',
 };
 
-export const Divider: React.FC<DividerProps> = ({ 
-  orientation = 'horizontal',
-  spacing = 'md'
-}) => {
-  const className = [
-    `textui-divider ${orientation}`,
-    spacingClasses[spacing]
-  ].join(' ');
-  
-  if (orientation === 'vertical') {
-    return <div className={className} />;
+export class Divider extends BaseComponent<DividerProps> {
+  protected defaultClassName = 'textui-divider';
+
+  render() {
+    const { orientation = 'horizontal', spacing = 'md' } = this.props;
+    const className = [
+      this.getMergedClassName(),
+      orientation,
+      spacingClasses[spacing]
+    ].join(' ');
+
+    if (orientation === 'vertical') {
+      return <div className={className} />;
+    }
+
+    return <hr className={className} />;
   }
-  
-  return <hr className={className} />;
-}; 
+}

--- a/src/renderer/components/Text.tsx
+++ b/src/renderer/components/Text.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { TextComponent } from '../types';
+import { BaseComponent, type BaseComponentProps } from './BaseComponent';
 
 type TextVariant = 'h1' | 'h2' | 'h3' | 'p' | 'small' | 'caption';
 
-interface TextProps extends TextComponent {
+interface TextProps extends TextComponent, BaseComponentProps {
   variant?: TextVariant;
   value: string;
   size?: 'xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl';
@@ -12,12 +13,12 @@ interface TextProps extends TextComponent {
 }
 
 const variantClasses: Record<TextVariant, string> = {
-  h1: 'textui-text h1',
-  h2: 'textui-text h2',
-  h3: 'textui-text h3',
-  p: 'textui-text p',
-  small: 'textui-text small',
-  caption: 'textui-text caption',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  p: 'p',
+  small: 'small',
+  caption: 'caption',
 };
 
 const sizeClasses: Record<string, string> = {
@@ -36,21 +37,21 @@ const weightClasses: Record<string, string> = {
   bold: 'font-bold',
 };
 
-export const Text: React.FC<TextProps> = ({ 
-  variant = 'p', 
-  value, 
-  size, 
-  weight, 
-  color 
-}) => {
-  const Component = variant.startsWith('h') ? variant : 'p';
-  
-  const className = [
-    variantClasses[variant],
-    size && sizeClasses[size],
-    weight && weightClasses[weight],
-    color
-  ].filter(Boolean).join(' ');
+export class Text extends BaseComponent<TextProps> {
+  protected defaultClassName = 'textui-text';
 
-  return React.createElement(Component, { className }, value);
-}; 
+  render() {
+    const { variant = 'p', value, size, weight, color } = this.props;
+    const Component = variant.startsWith('h') ? variant : 'p';
+
+    const className = [
+      this.getMergedClassName(),
+      variantClasses[variant],
+      size && sizeClasses[size],
+      weight && weightClasses[weight],
+      color
+    ].filter(Boolean).join(' ');
+
+    return React.createElement(Component, { className }, value);
+  }
+}


### PR DESCRIPTION
## Summary
- add `BaseComponent` with shared properties and class merging
- refactor core components to extend `BaseComponent`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859e30c3984832f8b3e3ca9ee1787ee