### PR TITLE
Add BaseComponent utility with tests

### DIFF
--- a/src/renderer/components/BaseComponent.tsx
+++ b/src/renderer/components/BaseComponent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export interface BaseComponentProps {
+  defaultClassName: string;
+  className?: string;
+  as?: React.ElementType;
+  [key: string]: any;
+}
+
+export function mergeClasses(defaultClass: string, customClass?: string): string {
+  return customClass ? `${defaultClass} ${customClass}` : defaultClass;
+}
+
+export const BaseComponent: React.FC<BaseComponentProps> = ({
+  defaultClassName,
+  className,
+  as: Component = 'div',
+  ...rest
+}) => {
+  const merged = mergeClasses(defaultClassName, className);
+  return <Component className={merged} {...rest} />;
+};

--- a/tests/integration/command-manager.test.js
+++ b/tests/integration/command-manager.test.js
@@ -31,7 +31,7 @@ describe('CommandManager 統合テスト', () => {
     fs.writeFileSync(testFilePath, testFile, 'utf-8');
 
     // CommandManagerをインポートしてテスト用インスタンスを作成
-    const { CommandManager } = require('../../src/services/command-manager');
+    const { CommandManager } = require('../../out/services/command-manager');
     commandManager = new CommandManager();
   });
 

--- a/tests/unit/base-component.test.js
+++ b/tests/unit/base-component.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { mergeClasses } = require('../../out/renderer/components/BaseComponent');
+
+describe('BaseComponent class name merging', () => {
+  it('merges default and custom class names', () => {
+    const result = mergeClasses('default', 'custom');
+    assert.strictEqual(result, 'default custom');
+  });
+
+  it('returns default class when custom is undefined', () => {
+    const result = mergeClasses('default');
+    assert.strictEqual(result, 'default');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,9 @@
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 	},
 	"exclude": ["node_modules", ".vscode-test", "out/test"],
-	"include": [
-		"src/**/*.ts",
-		"src/test/runTest.ts"
-	]
+        "include": [
+                "src/**/*.ts",
+                "src/**/*.tsx",
+                "src/test/runTest.ts"
+        ]
 }


### PR DESCRIPTION
## Summary
- add `BaseComponent` for merging default classes
- test class name merging in new unit test
- import compiled CommandManager in integration test
- compile TSX files via tsconfig include

## Testing
- `npm run compile-tests`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859e6cf4388832f9634b8cae292d514