### PR TITLE
Implement cache hit rate tracking

### DIFF
--- a/src/utils/cache-manager.ts
+++ b/src/utils/cache-manager.ts
@@ -19,6 +19,8 @@ export interface CacheOptions {
 export class CacheManager {
   private cache: Map<string, CacheEntry> = new Map();
   private options: CacheOptions;
+  private totalRequests = 0;
+  private cacheHits = 0;
 
   constructor(options: Partial<CacheOptions> = {}) {
     this.options = {
@@ -53,6 +55,7 @@ export class CacheManager {
    * キャッシュから値を取得
    */
   get(dsl: TextUIDSL, format: ExportFormat): string | null {
+    this.totalRequests++;
     const key = this.generateKey(dsl, format);
     const entry = this.cache.get(key);
 
@@ -66,6 +69,7 @@ export class CacheManager {
       return null;
     }
 
+    this.cacheHits++;
     return entry.content;
   }
 
@@ -73,6 +77,7 @@ export class CacheManager {
    * キャッシュに値を保存
    */
   set(dsl: TextUIDSL, format: ExportFormat, content: string): void {
+    this.totalRequests++;
     const key = this.generateKey(dsl, format);
     const hash = this.hashString(JSON.stringify(dsl));
 
@@ -131,10 +136,11 @@ export class CacheManager {
    * キャッシュ統計を取得
    */
   getStats(): { size: number; maxSize: number; hitRate: number } {
+    const hitRate = this.totalRequests === 0 ? 0 : this.cacheHits / this.totalRequests;
     return {
       size: this.cache.size,
       maxSize: this.options.maxSize,
-      hitRate: 0 // TODO: ヒット率の計算を実装
+      hitRate
     };
   }
 

--- a/tests/unit/cache-manager.test.js
+++ b/tests/unit/cache-manager.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const { CacheManager } = require('../../out/utils/cache-manager');
+
+describe('CacheManager', () => {
+  it('calculates hit rate correctly', () => {
+    const manager = new CacheManager({ ttl: 5000, maxSize: 5 });
+    const dsl = { page: { id: '1', components: [] } };
+    const format = 'html';
+
+    // first get should miss
+    assert.strictEqual(manager.get(dsl, format), null);
+
+    // store result
+    manager.set(dsl, format, 'cached');
+
+    // second get should hit
+    assert.strictEqual(manager.get(dsl, format), 'cached');
+
+    const stats = manager.getStats();
+    assert.strictEqual(stats.size, 1);
+    assert.strictEqual(stats.maxSize, 5);
+    assert.ok(Math.abs(stats.hitRate - 1 / 3) < 1e-6);
+  });
+});


### PR DESCRIPTION
## Summary
- track cache requests and hits in `CacheManager`
- compute hit rate in `getStats`
- test hit rate calculations

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859e7198200832fb36470696ddf0d44