### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
 
   integration:
     name: Integration Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: test
     


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/5](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `Integration Tests` job to explicitly define the permissions for the `GITHUB_TOKEN`. Since the job primarily involves checking out code and running tests, the minimal required permission is `contents: read`. This ensures that the job has only the necessary access to the repository contents and no write access.

The `permissions` block should be added directly under the `name` key of the `Integration Tests` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
