### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
 
   build:
     name: Build Extension
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [test, lint]
     


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/4](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/4)

To fix the issue, add a `permissions` block to the `Build Extension` job. Since the job does not require write access to the repository, the permissions can be limited to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimal permissions necessary for the job to execute.

The changes should be made in the `.github/workflows/ci.yml` file, specifically within the `Build Extension` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
