### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
 
   lint:
     name: Lint & Format Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/3](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block to the `lint` job in the workflow file. The `lint` job only needs read access to the repository contents to perform linting and formatting checks. Therefore, the `permissions` block should specify `contents: read`.

This change ensures that the `lint` job does not inherit unnecessary write permissions from the repository or organization defaults, reducing the risk of unintended modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
