### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     name: Test Suite
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/2](https://github.com/kamoshika-san/TextUI-Designer/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `test` job. Based on the actions performed in the job, it only requires `contents: read` permission to access the repository's code. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for the `test` job, aligning it with the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
