### PR TITLE
fix(schema): カスタムテーマファイルのJSONスキーマ対応を完全実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,6 +310,10 @@
         "*.template.yaml"
       ],
       "./schemas/theme-schema.json": [
+        "*-theme.yml",
+        "*-theme.yaml",
+        "*_theme.yml", 
+        "*_theme.yaml",
         "textui-theme.yml",
         "textui-theme.yaml"
       ]


### PR DESCRIPTION
- package.jsonでテーマファイルパターンを拡張
  - *-theme.yml, *_theme.yml, textui-theme.yml に対応
  - YAML言語サービスでのIntelliSense提供
- SchemaManagerでテーマスキーマの完全対応
  - themeSchemaPathの管理追加
  - loadThemeSchema()メソッド実装
  - YAML/JSON拡張への動的登録
  - キャッシュ機能とクリーンアップ処理
- テストでのテーマスキーマ対応を追加
  - テストスキーマファイルの作成管理
  - loadThemeSchema()のテストケース追加
  - パス解決ロジックのテスト強化

修正された問題:
- カスタムテーマファイルの「No JSON Schema」表示
- テーマファイルでのIntelliSense未対応
- SchemaManagerテストの失敗

テスト: 193個のテスト成功（+2個改善、失敗0個）