### PR TITLE
Fix ErrorHandler registration in DI

### DIFF
--- a/src/services/service-initializer.ts
+++ b/src/services/service-initializer.ts
@@ -102,11 +102,14 @@ export class ServiceInitializer {
    */
   private async registerServices(): Promise<void> {
     // 基本サービスの登録
-    this.container.register(ServiceTokens.ERROR_HANDLER, ErrorHandler);
+    this.container.registerFactory(ServiceTokens.ERROR_HANDLER, () => {
+      return ErrorHandler;
+    });
 
     // SchemaManagerの登録
     this.container.registerFactory(ServiceTokens.SCHEMA_MANAGER, () => {
-      return new SchemaManager(this.context);
+      const errorHandler = this.container.resolve<typeof ErrorHandler>(ServiceTokens.ERROR_HANDLER);
+      return new SchemaManager(this.context, undefined, { errorHandler });
     });
 
     // ThemeManagerの登録
@@ -133,12 +136,14 @@ export class ServiceInitializer {
 
     // TemplateServiceの登録
     this.container.registerFactory(ServiceTokens.TEMPLATE_SERVICE, () => {
-      return new TemplateService();
+      const errorHandler = this.container.resolve<typeof ErrorHandler>(ServiceTokens.ERROR_HANDLER);
+      return new TemplateService(errorHandler);
     });
 
     // SettingsServiceの登録
     this.container.registerFactory(ServiceTokens.SETTINGS_SERVICE, () => {
-      return new SettingsService();
+      const errorHandler = this.container.resolve<typeof ErrorHandler>(ServiceTokens.ERROR_HANDLER);
+      return new SettingsService(undefined, errorHandler);
     });
 
     // DiagnosticManagerの登録

--- a/src/services/template-service.ts
+++ b/src/services/template-service.ts
@@ -11,8 +11,8 @@ export class TemplateService {
   private parser: RefactoredTemplateParser;
   private isInitialized: boolean = false;
 
-  constructor() {
-    this.parser = new RefactoredTemplateParser();
+  constructor(errorHandler: typeof ErrorHandler = ErrorHandler) {
+    this.parser = new RefactoredTemplateParser(errorHandler);
   }
 
   /**


### PR DESCRIPTION
Correct `ErrorHandler` DI registration and update dependent services to properly receive it.

The `ErrorHandler` class contains only static methods, meaning dependent services expect to receive the class constructor itself, not an instance. The previous DI registration method was inconsistent and led to runtime errors when services attempted to invoke `ErrorHandler` methods. This PR changes the registration to `registerFactory` which explicitly returns the `ErrorHandler` class constructor, satisfying the dependency expectations and resolving the errors. It also updates `SchemaManager`, `SettingsService`, and `TemplateService` to correctly inject and use this dependency.