### PR TITLE
Fix error handling in deactivate function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,5 +49,8 @@ export function deactivate(): void {
     }
 
     logger.info('TextUI Designer拡張の非アクティベーション完了');
-  }, '拡張機能の非アクティベーション');
+  }, {
+    errorMessage: '拡張機能の非アクティベーション',
+    logLevel: 'warn'
+  });
 } 


### PR DESCRIPTION
Fix `deactivate` to pass an options object to `ErrorHandler.withErrorHandlingSync` to restore `logLevel: 'warn'`.