### PR TITLE
Fix error handling in activate function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ let lifecycleManager: ExtensionLifecycleManager | undefined;
  * 拡張機能のアクティベーション
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  await ErrorHandler.withErrorHandling(async () => {
+  const result = await ErrorHandler.withErrorHandling(async () => {
     logger.info('TextUI Designer拡張をアクティブ化中...');
 
     // メモリ追跡システムの初期化
@@ -25,7 +25,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await lifecycleManager.activate();
     
     logger.info('TextUI Designer拡張のアクティベーション完了');
-  }, '拡張機能のアクティベーション');
+  }, {
+    errorMessage: '拡張機能のアクティベーション中にエラーが発生しました',
+    rethrow: true,
+    showToUser: true
+  });
+  
+  // Since rethrow is true, this will only be reached on success
+  // and result will not be null
+  return result as void;
 }
 
 /**
@@ -49,5 +57,9 @@ export function deactivate(): void {
     }
 
     logger.info('TextUI Designer拡張の非アクティベーション完了');
-  }, '拡張機能の非アクティベーション');
+  }, {
+    errorMessage: '拡張機能の非アクティベーション中にエラーが発生しました',
+    showToUser: false,
+    logLevel: 'error'
+  });
 } 


### PR DESCRIPTION
Restore proper error handling configuration and API contract for `activate` and `deactivate` functions.

The previous implementation used a simple string instead of a configuration object for `ErrorHandler.withErrorHandling`, which prevented activation errors from propagating to VS Code (due to missing `rethrow: true`) and broke the `activate` function's public API contract by not returning its result. This PR fixes these issues by passing the correct configuration object and ensuring the `activate` function returns its result.