### PR TITLE
Add command-manifest checker, update export menu condition, add extensibility unit test, and document custom exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ page:
 - **スニペット**: `tui:form`等のテンプレートで高速入力
 - **エクスポート**: プレビュー画面またはコマンドパレットからワンクリックでHTML/React/Pug形式に出力
 
+### 🔌 拡張者向け: カスタムエクスポーター
+
+- `ExportManager#registerExporter(format, exporter)` で独自フォーマットを追加できます。
+- `exporter` は `export(dsl, options)` と `getFileExtension()` を実装します。
+- 既定設定 `textui-designer.export.defaultFormat` は `html/react/pug` の3形式のみを対象とします。
+  - カスタム形式を既定値として直接選ぶ運用は想定していません。
+  - カスタム形式は拡張側コードからオプション指定で扱ってください。
+
 ## サポートコンポーネント一覧
 - Text（h1, h2, h3, p, small, caption）
 - Alert（info, warning, success, error）

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
         },
         {
           "command": "textui-designer.export",
-          "when": "resourceExtname == .tui.yml",
+          "when": "resourceLangId == yaml",
           "group": "navigation"
         }
       ]
@@ -368,6 +368,7 @@
     "build-webview": "vite build",
     "dev-webview": "vite",
     "sync:commands": "npm run compile && node ./scripts/sync-command-manifest.cjs",
+    "check:commands": "npm run compile && node ./scripts/check-command-manifest.cjs",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",

--- a/scripts/check-command-manifest.cjs
+++ b/scripts/check-command-manifest.cjs
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const workspaceRoot = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(workspaceRoot, 'package.json');
+const commandCatalogPath = path.join(workspaceRoot, 'out', 'services', 'command-catalog.js');
+
+if (!fs.existsSync(commandCatalogPath)) {
+  throw new Error(
+    `command-catalog のビルド成果物が見つかりません: ${commandCatalogPath}\n` +
+      '先に `npm run compile` を実行してください。'
+  );
+}
+
+const {
+  getPackageCommandContributions,
+  getPackageMenuContributions
+} = require(commandCatalogPath);
+
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const manifestCommands = pkg.contributes?.commands || [];
+const manifestMenus = pkg.contributes?.menus?.['editor/title'] || [];
+
+const catalogCommands = getPackageCommandContributions();
+const catalogMenus = getPackageMenuContributions()['editor/title'] || [];
+
+const normalize = (items) =>
+  [...items]
+    .map(item => JSON.stringify(item))
+    .sort();
+
+const commandDiffers = JSON.stringify(normalize(manifestCommands)) !== JSON.stringify(normalize(catalogCommands));
+const menuDiffers = JSON.stringify(normalize(manifestMenus)) !== JSON.stringify(normalize(catalogMenus));
+
+if (!commandDiffers && !menuDiffers) {
+  console.log('[check-command-manifest] package.json は command-catalog と同期済みです');
+  process.exit(0);
+}
+
+if (commandDiffers) {
+  console.error('[check-command-manifest] contributes.commands が command-catalog と不一致です');
+}
+if (menuDiffers) {
+  console.error('[check-command-manifest] contributes.menus["editor/title"] が command-catalog と不一致です');
+}
+
+console.error('[check-command-manifest] `npm run sync:commands` を実行して同期してください');
+process.exit(1);

--- a/src/services/command-catalog.ts
+++ b/src/services/command-catalog.ts
@@ -77,7 +77,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     menus: [
       {
         location: 'editor/title',
-        when: 'resourceExtname == .tui.yml',
+        when: 'resourceLangId == yaml',
         group: 'navigation'
       }
     ],

--- a/tests/unit/extensibility-service-factories-contract.test.js
+++ b/tests/unit/extensibility-service-factories-contract.test.js
@@ -1,0 +1,161 @@
+const assert = require('assert');
+
+function createSchemaManagerMock() {
+  return {
+    initializeCalled: 0,
+    cleanupCalled: 0,
+    async initialize() {
+      this.initializeCalled += 1;
+    },
+    async cleanup() {
+      this.cleanupCalled += 1;
+    },
+    async reinitialize() {},
+    async debugSchemas() {},
+    async loadSchema() {
+      return { type: 'object' };
+    },
+    async loadTemplateSchema() {
+      return { type: 'object' };
+    },
+    async loadThemeSchema() {
+      return { type: 'object' };
+    },
+    validateSchema() {
+      return { valid: true };
+    },
+    async registerSchema() {},
+    async unregisterSchema() {}
+  };
+}
+
+function createThemeManagerMock() {
+  return {
+    loadThemeCalled: 0,
+    watchThemeFileCalled: 0,
+    disposeCalled: 0,
+    async loadTheme() {
+      this.loadThemeCalled += 1;
+    },
+    generateCSSVariables() {
+      return ':root { --x: 1; }';
+    },
+    watchThemeFile(callback) {
+      this.watchThemeFileCalled += 1;
+      this.watchCallback = callback;
+    },
+    getThemePath() {
+      return undefined;
+    },
+    setThemePath() {},
+    dispose() {
+      this.disposeCalled += 1;
+    }
+  };
+}
+
+function createWebViewManagerMock() {
+  return {
+    appliedCss: [],
+    disposeCalled: 0,
+    async openPreview() {},
+    async updatePreview() {},
+    closePreview() {},
+    setLastTuiFile() {},
+    getLastTuiFile() {
+      return undefined;
+    },
+    applyThemeVariables(css) {
+      this.appliedCss.push(css);
+    },
+    notifyThemeChange() {},
+    dispose() {
+      this.disposeCalled += 1;
+    },
+    hasPanel() {
+      return false;
+    },
+    getPanel() {
+      return undefined;
+    },
+    openDevTools() {}
+  };
+}
+
+describe('拡張API契約: ServiceFactoryOverrides', () => {
+  let ServiceInitializer;
+
+  before(() => {
+    ({ ServiceInitializer } = require('../../out/services/service-initializer'));
+  });
+
+  it('Theme/Template/Settings のファクトリー差し替えを尊重する', async () => {
+    const context = {
+      subscriptions: [],
+      extensionPath: process.cwd()
+    };
+
+    const schemaManager = createSchemaManagerMock();
+    const themeManager = createThemeManagerMock();
+    const webViewManager = createWebViewManagerMock();
+
+    const templateService = {
+      async createTemplate() {},
+      async insertTemplate() {}
+    };
+
+    const settingsService = {
+      async openSettings() {},
+      async resetSettings() {},
+      async showSettings() {},
+      async showAutoPreviewSetting() {},
+      startWatching: () => ({ dispose() {} }),
+      hasConfigurationChanged: () => true
+    };
+
+    const exportManager = {
+      registerExporter() {},
+      unregisterExporter() {
+        return false;
+      },
+      async exportFromFile() {
+        return '';
+      },
+      getSupportedFormats() {
+        return [];
+      },
+      getFileExtension() {
+        return '';
+      },
+      clearCache() {},
+      clearFormatCache() {},
+      dispose() {}
+    };
+
+    const initializer = new ServiceInitializer(context, {
+      createSchemaManager: () => schemaManager,
+      createThemeManager: () => themeManager,
+      createWebViewManager: () => webViewManager,
+      createExportManager: () => exportManager,
+      createTemplateService: () => templateService,
+      createSettingsService: () => settingsService
+    });
+
+    const services = await initializer.initialize();
+
+    assert.strictEqual(services.themeManager, themeManager);
+    assert.strictEqual(services.templateService, templateService);
+    assert.strictEqual(services.settingsService, settingsService);
+
+    assert.strictEqual(schemaManager.initializeCalled, 1);
+    assert.strictEqual(themeManager.loadThemeCalled, 1);
+    assert.strictEqual(themeManager.watchThemeFileCalled, 1);
+    assert.deepStrictEqual(webViewManager.appliedCss, [':root { --x: 1; }']);
+
+    await initializer.cleanup();
+
+    assert.strictEqual(schemaManager.cleanupCalled, 1);
+    assert.strictEqual(webViewManager.disposeCalled, 1);
+    assert.strictEqual(themeManager.disposeCalled, 1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure `package.json` contributes stay in sync with the generated command catalog and make it easy to detect mismatches before publishing. 
- Broaden the editor menu condition for the Export command to trigger for YAML files rather than only `.tui.yml` extensions. 
- Verify that service factory overrides for extensibility are respected and lifecycle methods are invoked. 
- Document how to add custom exporters for extension authors.

### Description
- Added a new script `scripts/check-command-manifest.cjs` that compares `package.json` contributes against the runtime `command-catalog` and exits non-zero on mismatch. 
- Added an npm script `check:commands` which runs `npm run compile` then `node ./scripts/check-command-manifest.cjs`. 
- Adjusted the export command menu condition from `resourceExtname == .tui.yml` to `resourceLangId == yaml` in both `package.json` and `src/services/command-catalog.ts`. 
- Added a new unit test `tests/unit/extensibility-service-factories-contract.test.js` that exercises `ServiceInitializer` to confirm custom factory overrides and lifecycle behavior. 
- Extended `README.md` with a new "Custom Exporter" section that documents `ExportManager#registerExporter(format, exporter)`, the `export(dsl, options)` / `getFileExtension()` shape, and notes about default formats.

### Testing
- Ran unit tests with `npm run test:unit`, which executed the test suite including the new extensibility test and passed. 
- Executed the new command manifest check with `npm run check:commands` to validate `package.json` vs `command-catalog`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3cd785efc832f8917a9dc9c34b911)