### PR TITLE
feat: YAMLパーサでネストした `$include` 参照を解決する

### DIFF
--- a/src/services/webview/yaml-parser.ts
+++ b/src/services/webview/yaml-parser.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as YAML from 'yaml';
 import Ajv, { ErrorObject } from 'ajv';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { SchemaDefinition } from '../../types';
 import { PerformanceMonitor } from '../../utils/performance-monitor';
 import { ConfigManager } from '../../utils/config-manager';
@@ -74,12 +76,13 @@ export class YamlParser {
 
       // YAMLパース処理を非同期で実行
       const yaml = await this.parseYamlContent(yamlContent, fileName);
+      const resolvedYaml = await this.resolveTemplateIncludes(yaml, fileName, new Set<string>());
 
       // スキーマバリデーションを実行
-      await this.validateYamlSchema(yaml, yamlContent, fileName);
+      await this.validateYamlSchema(resolvedYaml, yamlContent, fileName);
 
       return {
-        data: yaml,
+        data: resolvedYaml,
         fileName: fileName,
         content: yamlContent
       };
@@ -105,6 +108,119 @@ export class YamlParser {
       console.error('[YamlParser] YAMLパースエラー:', parseError);
       throw this.createParseError(parseError, yamlContent, fileName);
     }
+  }
+
+  /**
+   * $include を再帰的に解決
+   */
+  private async resolveTemplateIncludes(node: unknown, currentFile: string, includeStack: Set<string>): Promise<unknown> {
+    if (Array.isArray(node)) {
+      const resolvedItems: unknown[] = [];
+
+      for (const item of node) {
+        if (this.isIncludeDirective(item)) {
+          const included = await this.loadInclude(item.$include, currentFile, includeStack);
+          const flattened = Array.isArray(included) ? included : [included];
+          resolvedItems.push(...flattened);
+          continue;
+        }
+
+        resolvedItems.push(await this.resolveTemplateIncludes(item, currentFile, includeStack));
+      }
+
+      return resolvedItems;
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = await this.resolveTemplateIncludes(value, currentFile, includeStack);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private async loadInclude(
+    includeSpec: { template: string; params?: Record<string, unknown> },
+    currentFile: string,
+    includeStack: Set<string>
+  ): Promise<unknown> {
+    const baseDir = path.dirname(currentFile);
+    const includePath = path.resolve(baseDir, includeSpec.template);
+
+    if (includeStack.has(includePath)) {
+      const error = new Error(`循環参照を検出しました: ${[...includeStack, includePath].join(' -> ')}`);
+      error.name = 'YamlParseError';
+      throw error;
+    }
+
+    includeStack.add(includePath);
+
+    try {
+      const includeContent = await fs.readFile(includePath, 'utf-8');
+      const includeYaml = await this.parseYamlContent(includeContent, includePath);
+      const withParams = this.applyIncludeParams(includeYaml, includeSpec.params ?? {});
+
+      return await this.resolveTemplateIncludes(withParams, includePath, includeStack);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'YamlParseError') {
+        throw error;
+      }
+
+      const fileError = new Error(`テンプレート読み込みに失敗しました: ${includeSpec.template} (${String(error)})`);
+      fileError.name = 'YamlParseError';
+      throw fileError;
+    } finally {
+      includeStack.delete(includePath);
+    }
+  }
+
+  private applyIncludeParams(node: unknown, params: Record<string, unknown>): unknown {
+    if (typeof node === 'string') {
+      return node.replace(/\{\{\s*\$params\.([\w.]+)\s*\}\}/g, (_match, expression: string) => {
+        const resolved = expression.split('.').reduce<unknown>((acc, key) => {
+          if (!this.isRecord(acc)) {
+            return undefined;
+          }
+
+          return acc[key];
+        }, params);
+
+        return resolved === undefined || resolved === null ? '' : String(resolved);
+      });
+    }
+
+    if (Array.isArray(node)) {
+      return node.map(item => this.applyIncludeParams(item, params));
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = this.applyIncludeParams(value, params);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private isIncludeDirective(value: unknown): value is { $include: { template: string; params?: Record<string, unknown> } } {
+    if (!this.isRecord(value) || !this.isRecord(value.$include)) {
+      return false;
+    }
+
+    return typeof value.$include.template === 'string';
   }
 
   /**

--- a/tests/unit/yaml-parser.test.js
+++ b/tests/unit/yaml-parser.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const os = require('os');
+const fs = require('fs');
 const Module = require('module');
 
 describe('YamlParser スキーマ検証', () => {
@@ -133,5 +135,58 @@ describe('YamlParser スキーマ検証', () => {
         return true;
       }
     );
+  });
+
+  it('$include で参照したテンプレートを解決し、ネストした参照も展開する', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-'));
+    const nestedTemplatePath = path.join(tmpDir, 'nested.template.yml');
+    const templatePath = path.join(tmpDir, 'form.template.yml');
+
+    fs.writeFileSync(nestedTemplatePath, `- Text:\n    variant: p\n    value: \"Nested: {{ $params.description }}\"\n`, 'utf8');
+    fs.writeFileSync(templatePath, `- Text:\n    variant: h2\n    value: \"{{ $params.title }}\"\n- $include:\n    template: \"./nested.template.yml\"\n    params:\n      description: \"{{ $params.description }}\"\n`, 'utf8');
+
+    const mainContent = `page:\n  components:\n    - $include:\n        template: \"./form.template.yml\"\n        params:\n          title: \"Hello\"\n          description: \"World\"\n`;
+
+    try {
+      setActiveEditor(mainContent);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'page.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+      const result = await parser.parseYamlFile();
+
+      assert.strictEqual(result.data.page.components[0].Text.value, 'Hello');
+      assert.strictEqual(result.data.page.components[1].Text.value, 'Nested: World');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('$include の循環参照を検出して YamlParseError を返す', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-cycle-'));
+    const templateAPath = path.join(tmpDir, 'a.template.yml');
+    const templateBPath = path.join(tmpDir, 'b.template.yml');
+
+    fs.writeFileSync(templateAPath, `- $include:\n    template: \"./b.template.yml\"\n`, 'utf8');
+    fs.writeFileSync(templateBPath, `- $include:\n    template: \"./a.template.yml\"\n`, 'utf8');
+
+    try {
+      setActiveEditor(`page:\n  components:\n    - $include:\n        template: \"./a.template.yml\"\n`);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'main.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+
+      await assert.rejects(
+        () => parser.parseYamlFile(),
+        (error) => {
+          assert.strictEqual(error.name, 'YamlParseError');
+          assert.match(error.message, /循環参照/);
+          return true;
+        }
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- 大規模UIをファイル分割して管理できるように、`.template.yml` を参照する `$include` 機能をパース時に解決して統合する必要があったため。 
- テンプレートに `params` を渡して再利用性を高め、ネストや循環参照の検出で安全性を担保するため。 

### Description
- `YamlParser.parseYamlFile` の処理フローを変更して、パース後に `resolveTemplateIncludes` を呼び出し、解決後のデータをスキーマ検証に渡すようにしました。 
- `$include` の解決ロジックとして `resolveTemplateIncludes` / `loadInclude` / `applyIncludeParams` を実装し、相対パス解決・ファイル読み込み（`fs/promises`）・配列のフラット展開を行うようにしました。 
- `{{ $params.xxx }}` 形式の文字列展開を再帰的に適用し、パラメータ付きテンプレートのサポートを追加しました。 
- 循環参照検出を追加し、検出時は `YamlParseError` を投げて明示的に失敗するようにしました。 
- 変更ファイル: `src/services/webview/yaml-parser.ts` に実装を追加し、`tests/unit/yaml-parser.test.js` にネスト展開と循環検出の単体テストを追加しました。 

### Testing
- `npm run lint` を実行して静的検査を行い問題ありませんでした。 
- `npm test`（ユニットテスト）を実行し、ユニットテスト全件（216件）が通過しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fd525a88832faa45e5d3878606f8)