### PR TITLE
Support $include directives in schemas and resolve includes in YAML parser

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -1,305 +1,535 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://example.com/textui/v0/schema.json",
-    "title": "TextUI Designer DSL v0",
-    "description": "Minimum viable component set for TextUI Designer (v0).",
-    "type": "object",
-    "properties": {
-      "page": {
-        "type": "object",
-        "description": "Page-level metadataとトップレベルのUI要素",
-        "required": ["components"],
-        "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "layout": {
-            "type": "string",
-            "enum": ["vertical", "horizontal", "flex", "grid"]
-          },
-          "components": { "$ref": "#/definitions/componentArray" }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/textui/v0/schema.json",
+  "title": "TextUI Designer DSL v0",
+  "description": "Minimum viable component set for TextUI Designer (v0).",
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "object",
+      "description": "Page-level metadataとトップレベルのUI要素",
+      "required": [
+        "components"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string",
+          "enum": [
+            "vertical",
+            "horizontal",
+            "flex",
+            "grid"
+          ]
+        },
+        "components": {
+          "$ref": "#/definitions/componentArray"
         }
-      },
-      "components": { "$ref": "#/definitions/componentArray" }
-    },
-    "definitions": {
-      "componentArray": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/component" }
-      },
-      "component": {
-        "type": "object",
-        "description": "Tagged union of all v0 components",
-        "oneOf": [
-          { "$ref": "#/definitions/Text" },
-          { "$ref": "#/definitions/Input" },
-          { "$ref": "#/definitions/Button" },
-          { "$ref": "#/definitions/Form" },
-          { "$ref": "#/definitions/Checkbox" },
-          { "$ref": "#/definitions/Radio" },
-          { "$ref": "#/definitions/Select" },
-          { "$ref": "#/definitions/Divider" },
-          { "$ref": "#/definitions/Container" },
-          { "$ref": "#/definitions/Alert" }
-        ]
-      },
-  
-      "Text": {
-        "type": "object",
-        "required": ["Text"],
-        "properties": {
-          "Text": {
-            "type": "object",
-            "required": ["variant", "value"],
-            "properties": {
-              "variant": {
-                "type": "string",
-                "enum": ["h1", "h2", "h3", "p", "small", "caption"],
-                "description": "テキストの見た目（見出し・段落・注釈など）を指定します。"
-              },
-              "value": { "type": "string", "description": "表示するテキスト内容。" }
-            },
-            "additionalProperties": false,
-            "description": "テキスト（見出し・段落など）を表示するコンポーネント。\n利用可能な属性: variant, value"
-          }
-        },
-        "additionalProperties": false,
-        "description": "テキスト（見出し・段落など）を表示するコンポーネント。"
-      },
-  
-      "Input": {
-        "type": "object",
-        "required": ["Input"],
-        "properties": {
-          "Input": {
-            "type": "object",
-            "required": ["label", "name", "type"],
-            "properties": {
-              "label": { "type": "string", "description": "入力欄のラベル（表示名）。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "type": {
-                "type": "string",
-                "enum": ["text", "email", "password", "number", "multiline"],
-                "description": "入力欄の種類（テキスト・メール・パスワード・数値・複数行）。"
-              },
-              "required": { "type": "boolean", "default": false, "description": "必須入力かどうか。trueで必須。" },
-              "placeholder": { "type": "string", "description": "入力欄のプレースホルダー（薄い説明文）。" }
-            },
-            "additionalProperties": false,
-            "description": "テキスト入力用コンポーネント。\n利用可能な属性: label, name, type, required, placeholder"
-          }
-        },
-        "additionalProperties": false,
-        "description": "テキスト入力用コンポーネント。"
-      },
-  
-      "Button": {
-        "type": "object",
-        "required": ["Button"],
-        "properties": {
-          "Button": {
-            "type": "object",
-            "required": ["label"],
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["primary", "secondary", "submit"],
-                "default": "primary",
-                "description": "ボタンの種類（主ボタン・副ボタン・送信ボタン）。"
-              },
-              "label": { "type": "string", "description": "ボタンに表示するテキスト。" },
-              "submit": { "type": "boolean", "default": false, "description": "フォーム送信ボタンかどうか。" }
-            },
-            "additionalProperties": false,
-            "description": "ボタンコンポーネント。\n利用可能な属性: kind, label, submit"
-          }
-        },
-        "additionalProperties": false,
-        "description": "ボタンコンポーネント。"
-      },
-  
-      "Checkbox": {
-        "type": "object",
-        "required": ["Checkbox"],
-        "properties": {
-          "Checkbox": {
-            "type": "object",
-            "required": ["label", "name"],
-            "properties": {
-              "label": { "type": "string", "description": "チェックボックスのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "required": { "type": "boolean", "default": false, "description": "必須項目かどうか。" }
-            },
-            "additionalProperties": false,
-            "description": "チェックボックスコンポーネント。\n利用可能な属性: label, name, required"
-          }
-        },
-        "additionalProperties": false,
-        "description": "チェックボックスコンポーネント。"
-      },
-  
-      "Radio": {
-        "type": "object",
-        "required": ["Radio"],
-        "properties": {
-          "Radio": {
-            "type": "object",
-            "required": ["label", "name", "options"],
-            "properties": {
-              "label": { "type": "string", "description": "ラジオボタンのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "options": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["label", "value"],
-                  "properties": {
-                    "label": { "type": "string", "description": "選択肢の表示名。" },
-                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
-                  },
-                  "additionalProperties": false,
-                  "description": "ラジオボタンの選択肢。"
-                },
-                "minItems": 1,
-                "description": "選択肢の配列。"
-              }
-            },
-            "additionalProperties": false,
-            "description": "ラジオボタンコンポーネント。\n利用可能な属性: label, name, options"
-          }
-        },
-        "additionalProperties": false,
-        "description": "ラジオボタンコンポーネント。"
-      },
-  
-      "Select": {
-        "type": "object",
-        "required": ["Select"],
-        "properties": {
-          "Select": {
-            "type": "object",
-            "required": ["label", "name", "options"],
-            "properties": {
-              "label": { "type": "string", "description": "セレクトボックスのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "options": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["label", "value"],
-                  "properties": {
-                    "label": { "type": "string", "description": "選択肢の表示名。" },
-                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
-                  },
-                  "additionalProperties": false,
-                  "description": "セレクトボックスの選択肢。"
-                },
-                "minItems": 1,
-                "description": "選択肢の配列。"
-              },
-              "multiple": { "type": "boolean", "default": false, "description": "複数選択を許可するか。" },
-              "placeholder": { "type": "string", "description": "セレクトボックスのプレースホルダー（未選択時の表示）。" }
-            },
-            "additionalProperties": false,
-            "description": "セレクトボックスコンポーネント。\n利用可能な属性: label, name, options, multiple, placeholder"
-          }
-        },
-        "additionalProperties": false,
-        "description": "セレクトボックスコンポーネント。"
-      },
-  
-      "Divider": {
-        "type": "object",
-        "required": ["Divider"],
-        "properties": {
-          "Divider": {
-            "type": "object",
-            "properties": {
-              "orientation": {
-                "type": "string",
-                "enum": ["horizontal", "vertical"],
-                "default": "horizontal",
-                "description": "区切り線の向き（横・縦）。"
-              }
-            },
-            "additionalProperties": false,
-            "description": "区切り線コンポーネント。\n利用可能な属性: orientation"
-          }
-        },
-        "additionalProperties": false,
-        "description": "区切り線コンポーネント。"
-      },
-  
-      "Container": {
-        "type": "object",
-        "required": ["Container"],
-        "properties": {
-          "Container": {
-            "type": "object",
-            "properties": {
-              "layout": {
-                "type": "string",
-                "enum": ["vertical", "horizontal", "flex", "grid"],
-                "description": "子コンポーネントの配置方法。"
-              },
-              "components": { "$ref": "#/definitions/componentArray", "description": "子コンポーネントの配列。" }
-            },
-            "required": ["components"],
-            "additionalProperties": false,
-            "description": "レイアウト用コンテナコンポーネント。\n利用可能な属性: layout, components"
-          }
-        },
-        "additionalProperties": false,
-        "description": "レイアウト用コンテナコンポーネント。"
-      },
-  
-      "Alert": {
-        "type": "object",
-        "required": ["Alert"],
-        "properties": {
-          "Alert": {
-            "type": "object",
-            "required": ["variant", "message"],
-            "properties": {
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"],
-                "default": "info",
-                "description": "アラートの種類（情報・成功・警告・エラー）。"
-              },
-              "message": { "type": "string", "description": "表示するメッセージ内容。" }
-            },
-            "additionalProperties": false,
-            "description": "アラートコンポーネント。\n利用可能な属性: variant, message"
-          }
-        },
-        "additionalProperties": false,
-        "description": "アラートコンポーネント。"
-      },
-  
-      "Form": {
-        "type": "object",
-        "required": ["Form"],
-        "properties": {
-          "Form": {
-            "type": "object",
-            "properties": {
-              "id": { "type": "string", "description": "フォームのID。" },
-              "fields": { "$ref": "#/definitions/componentArray", "description": "フォーム内の入力フィールド群。" },
-              "actions": {
-                "type": "array",
-                "items": { "$ref": "#/definitions/Button" },
-                "description": "フォーム下部のボタン群。"
-              }
-            },
-            "required": ["fields"],
-            "additionalProperties": false,
-            "description": "フォームコンポーネント。\n利用可能な属性: id, fields, actions"
-          }
-        },
-        "additionalProperties": false,
-        "description": "フォームコンポーネント。"
       }
     },
-    "additionalProperties": false
-  }
-  
+    "components": {
+      "$ref": "#/definitions/componentArray"
+    }
+  },
+  "definitions": {
+    "componentArray": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/includeDirective"
+          }
+        ]
+      }
+    },
+    "component": {
+      "type": "object",
+      "description": "Tagged union of all v0 components",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Text"
+        },
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "$ref": "#/definitions/Button"
+        },
+        {
+          "$ref": "#/definitions/Form"
+        },
+        {
+          "$ref": "#/definitions/Checkbox"
+        },
+        {
+          "$ref": "#/definitions/Radio"
+        },
+        {
+          "$ref": "#/definitions/Select"
+        },
+        {
+          "$ref": "#/definitions/Divider"
+        },
+        {
+          "$ref": "#/definitions/Container"
+        },
+        {
+          "$ref": "#/definitions/Alert"
+        }
+      ]
+    },
+    "includeDirective": {
+      "type": "object",
+      "required": [
+        "$include"
+      ],
+      "properties": {
+        "$include": {
+          "type": "object",
+          "required": [
+            "template"
+          ],
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "参照するテンプレートファイルへの相対パス。"
+            },
+            "params": {
+              "type": "object",
+              "description": "テンプレートへ渡すパラメータ。",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "$include によるテンプレート参照。"
+    },
+    "Text": {
+      "type": "object",
+      "required": [
+        "Text"
+      ],
+      "properties": {
+        "Text": {
+          "type": "object",
+          "required": [
+            "variant",
+            "value"
+          ],
+          "properties": {
+            "variant": {
+              "type": "string",
+              "enum": [
+                "h1",
+                "h2",
+                "h3",
+                "p",
+                "small",
+                "caption"
+              ],
+              "description": "テキストの見た目（見出し・段落・注釈など）を指定します。"
+            },
+            "value": {
+              "type": "string",
+              "description": "表示するテキスト内容。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "テキスト（見出し・段落など）を表示するコンポーネント。\n利用可能な属性: variant, value"
+        }
+      },
+      "additionalProperties": false,
+      "description": "テキスト（見出し・段落など）を表示するコンポーネント。"
+    },
+    "Input": {
+      "type": "object",
+      "required": [
+        "Input"
+      ],
+      "properties": {
+        "Input": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "入力欄のラベル（表示名）。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "email",
+                "password",
+                "number",
+                "multiline"
+              ],
+              "description": "入力欄の種類（テキスト・メール・パスワード・数値・複数行）。"
+            },
+            "required": {
+              "type": "boolean",
+              "default": false,
+              "description": "必須入力かどうか。trueで必須。"
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "入力欄のプレースホルダー（薄い説明文）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "テキスト入力用コンポーネント。\n利用可能な属性: label, name, type, required, placeholder"
+        }
+      },
+      "additionalProperties": false,
+      "description": "テキスト入力用コンポーネント。"
+    },
+    "Button": {
+      "type": "object",
+      "required": [
+        "Button"
+      ],
+      "properties": {
+        "Button": {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "submit"
+              ],
+              "default": "primary",
+              "description": "ボタンの種類（主ボタン・副ボタン・送信ボタン）。"
+            },
+            "label": {
+              "type": "string",
+              "description": "ボタンに表示するテキスト。"
+            },
+            "submit": {
+              "type": "boolean",
+              "default": false,
+              "description": "フォーム送信ボタンかどうか。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "ボタンコンポーネント。\n利用可能な属性: kind, label, submit"
+        }
+      },
+      "additionalProperties": false,
+      "description": "ボタンコンポーネント。"
+    },
+    "Checkbox": {
+      "type": "object",
+      "required": [
+        "Checkbox"
+      ],
+      "properties": {
+        "Checkbox": {
+          "type": "object",
+          "required": [
+            "label",
+            "name"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "チェックボックスのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "required": {
+              "type": "boolean",
+              "default": false,
+              "description": "必須項目かどうか。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "チェックボックスコンポーネント。\n利用可能な属性: label, name, required"
+        }
+      },
+      "additionalProperties": false,
+      "description": "チェックボックスコンポーネント。"
+    },
+    "Radio": {
+      "type": "object",
+      "required": [
+        "Radio"
+      ],
+      "properties": {
+        "Radio": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "options"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "ラジオボタンのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "value"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "選択肢の表示名。"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ],
+                    "description": "選択肢の値。"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "ラジオボタンの選択肢。"
+              },
+              "minItems": 1,
+              "description": "選択肢の配列。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "ラジオボタンコンポーネント。\n利用可能な属性: label, name, options"
+        }
+      },
+      "additionalProperties": false,
+      "description": "ラジオボタンコンポーネント。"
+    },
+    "Select": {
+      "type": "object",
+      "required": [
+        "Select"
+      ],
+      "properties": {
+        "Select": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "options"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "セレクトボックスのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "value"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "選択肢の表示名。"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ],
+                    "description": "選択肢の値。"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "セレクトボックスの選択肢。"
+              },
+              "minItems": 1,
+              "description": "選択肢の配列。"
+            },
+            "multiple": {
+              "type": "boolean",
+              "default": false,
+              "description": "複数選択を許可するか。"
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "セレクトボックスのプレースホルダー（未選択時の表示）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "セレクトボックスコンポーネント。\n利用可能な属性: label, name, options, multiple, placeholder"
+        }
+      },
+      "additionalProperties": false,
+      "description": "セレクトボックスコンポーネント。"
+    },
+    "Divider": {
+      "type": "object",
+      "required": [
+        "Divider"
+      ],
+      "properties": {
+        "Divider": {
+          "type": "object",
+          "properties": {
+            "orientation": {
+              "type": "string",
+              "enum": [
+                "horizontal",
+                "vertical"
+              ],
+              "default": "horizontal",
+              "description": "区切り線の向き（横・縦）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "区切り線コンポーネント。\n利用可能な属性: orientation"
+        }
+      },
+      "additionalProperties": false,
+      "description": "区切り線コンポーネント。"
+    },
+    "Container": {
+      "type": "object",
+      "required": [
+        "Container"
+      ],
+      "properties": {
+        "Container": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "type": "string",
+              "enum": [
+                "vertical",
+                "horizontal",
+                "flex",
+                "grid"
+              ],
+              "description": "子コンポーネントの配置方法。"
+            },
+            "components": {
+              "$ref": "#/definitions/componentArray",
+              "description": "子コンポーネントの配列。"
+            }
+          },
+          "required": [
+            "components"
+          ],
+          "additionalProperties": false,
+          "description": "レイアウト用コンテナコンポーネント。\n利用可能な属性: layout, components"
+        }
+      },
+      "additionalProperties": false,
+      "description": "レイアウト用コンテナコンポーネント。"
+    },
+    "Alert": {
+      "type": "object",
+      "required": [
+        "Alert"
+      ],
+      "properties": {
+        "Alert": {
+          "type": "object",
+          "required": [
+            "variant",
+            "message"
+          ],
+          "properties": {
+            "variant": {
+              "type": "string",
+              "enum": [
+                "info",
+                "success",
+                "warning",
+                "error"
+              ],
+              "default": "info",
+              "description": "アラートの種類（情報・成功・警告・エラー）。"
+            },
+            "message": {
+              "type": "string",
+              "description": "表示するメッセージ内容。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "アラートコンポーネント。\n利用可能な属性: variant, message"
+        }
+      },
+      "additionalProperties": false,
+      "description": "アラートコンポーネント。"
+    },
+    "Form": {
+      "type": "object",
+      "required": [
+        "Form"
+      ],
+      "properties": {
+        "Form": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "フォームのID。"
+            },
+            "fields": {
+              "$ref": "#/definitions/componentArray",
+              "description": "フォーム内の入力フィールド群。"
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Button"
+              },
+              "description": "フォーム下部のボタン群。"
+            }
+          },
+          "required": [
+            "fields"
+          ],
+          "additionalProperties": false,
+          "description": "フォームコンポーネント。\n利用可能な属性: id, fields, actions"
+        }
+      },
+      "additionalProperties": false,
+      "description": "フォームコンポーネント。"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/template-schema.json
+++ b/schemas/template-schema.json
@@ -40,7 +40,14 @@
     "componentArray": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/component"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/includeDirective"
+          }
+        ]
       }
     },
     "component": {
@@ -78,6 +85,34 @@
           "$ref": "#/definitions/Alert"
         }
       ]
+    },
+    "includeDirective": {
+      "type": "object",
+      "required": [
+        "$include"
+      ],
+      "properties": {
+        "$include": {
+          "type": "object",
+          "required": [
+            "template"
+          ],
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "参照するテンプレートファイルへの相対パス。"
+            },
+            "params": {
+              "type": "object",
+              "description": "テンプレートへ渡すパラメータ。",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "$include によるテンプレート参照。"
     },
     "Text": {
       "type": "object",
@@ -490,38 +525,12 @@
   },
   "additionalProperties": false,
   "items": {
-    "type": "object",
-    "description": "Tagged union of all v0 components",
     "oneOf": [
       {
-        "$ref": "#/definitions/Text"
+        "$ref": "#/definitions/component"
       },
       {
-        "$ref": "#/definitions/Input"
-      },
-      {
-        "$ref": "#/definitions/Button"
-      },
-      {
-        "$ref": "#/definitions/Form"
-      },
-      {
-        "$ref": "#/definitions/Checkbox"
-      },
-      {
-        "$ref": "#/definitions/Radio"
-      },
-      {
-        "$ref": "#/definitions/Select"
-      },
-      {
-        "$ref": "#/definitions/Divider"
-      },
-      {
-        "$ref": "#/definitions/Container"
-      },
-      {
-        "$ref": "#/definitions/Alert"
+        "$ref": "#/definitions/includeDirective"
       }
     ]
   }

--- a/src/services/schema-manager.ts
+++ b/src/services/schema-manager.ts
@@ -91,18 +91,16 @@ export class SchemaManager implements ISchemaManager {
    * テンプレート用スキーマを生成
    */
   private async createTemplateSchema(): Promise<void> {
-    if (!fs.existsSync(this.templateSchemaPath)) {
-      try {
-        const schema = JSON.parse(fs.readFileSync(this.schemaPath, 'utf-8'));
-        const templateSchema = {
-          ...schema,
-          type: 'array',
-          items: schema.definitions.component
-        };
-        fs.writeFileSync(this.templateSchemaPath, JSON.stringify(templateSchema, null, 2), 'utf-8');
-      } catch (error) {
-        console.error('テンプレートスキーマの作成に失敗しました:', error);
-      }
+    try {
+      const schema = JSON.parse(fs.readFileSync(this.schemaPath, 'utf-8'));
+      const templateSchema = {
+        ...schema,
+        type: 'array',
+        items: schema.definitions.componentArray?.items ?? schema.definitions.component
+      };
+      fs.writeFileSync(this.templateSchemaPath, JSON.stringify(templateSchema, null, 2), 'utf-8');
+    } catch (error) {
+      console.error('テンプレートスキーマの作成に失敗しました:', error);
     }
   }
 

--- a/src/services/webview/yaml-parser.ts
+++ b/src/services/webview/yaml-parser.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as YAML from 'yaml';
 import Ajv, { ErrorObject } from 'ajv';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { SchemaDefinition } from '../../types';
 import { PerformanceMonitor } from '../../utils/performance-monitor';
 import { ConfigManager } from '../../utils/config-manager';
@@ -74,12 +76,13 @@ export class YamlParser {
 
       // YAMLパース処理を非同期で実行
       const yaml = await this.parseYamlContent(yamlContent, fileName);
+      const resolvedYaml = await this.resolveTemplateIncludes(yaml, fileName, new Set<string>());
 
       // スキーマバリデーションを実行
-      await this.validateYamlSchema(yaml, yamlContent, fileName);
+      await this.validateYamlSchema(resolvedYaml, yamlContent, fileName);
 
       return {
-        data: yaml,
+        data: resolvedYaml,
         fileName: fileName,
         content: yamlContent
       };
@@ -105,6 +108,119 @@ export class YamlParser {
       console.error('[YamlParser] YAMLパースエラー:', parseError);
       throw this.createParseError(parseError, yamlContent, fileName);
     }
+  }
+
+  /**
+   * $include を再帰的に解決
+   */
+  private async resolveTemplateIncludes(node: unknown, currentFile: string, includeStack: Set<string>): Promise<unknown> {
+    if (Array.isArray(node)) {
+      const resolvedItems: unknown[] = [];
+
+      for (const item of node) {
+        if (this.isIncludeDirective(item)) {
+          const included = await this.loadInclude(item.$include, currentFile, includeStack);
+          const flattened = Array.isArray(included) ? included : [included];
+          resolvedItems.push(...flattened);
+          continue;
+        }
+
+        resolvedItems.push(await this.resolveTemplateIncludes(item, currentFile, includeStack));
+      }
+
+      return resolvedItems;
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = await this.resolveTemplateIncludes(value, currentFile, includeStack);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private async loadInclude(
+    includeSpec: { template: string; params?: Record<string, unknown> },
+    currentFile: string,
+    includeStack: Set<string>
+  ): Promise<unknown> {
+    const baseDir = path.dirname(currentFile);
+    const includePath = path.resolve(baseDir, includeSpec.template);
+
+    if (includeStack.has(includePath)) {
+      const error = new Error(`循環参照を検出しました: ${[...includeStack, includePath].join(' -> ')}`);
+      error.name = 'YamlParseError';
+      throw error;
+    }
+
+    includeStack.add(includePath);
+
+    try {
+      const includeContent = await fs.readFile(includePath, 'utf-8');
+      const includeYaml = await this.parseYamlContent(includeContent, includePath);
+      const withParams = this.applyIncludeParams(includeYaml, includeSpec.params ?? {});
+
+      return await this.resolveTemplateIncludes(withParams, includePath, includeStack);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'YamlParseError') {
+        throw error;
+      }
+
+      const fileError = new Error(`テンプレート読み込みに失敗しました: ${includeSpec.template} (${String(error)})`);
+      fileError.name = 'YamlParseError';
+      throw fileError;
+    } finally {
+      includeStack.delete(includePath);
+    }
+  }
+
+  private applyIncludeParams(node: unknown, params: Record<string, unknown>): unknown {
+    if (typeof node === 'string') {
+      return node.replace(/\{\{\s*\$params\.([\w.]+)\s*\}\}/g, (_match, expression: string) => {
+        const resolved = expression.split('.').reduce<unknown>((acc, key) => {
+          if (!this.isRecord(acc)) {
+            return undefined;
+          }
+
+          return acc[key];
+        }, params);
+
+        return resolved === undefined || resolved === null ? '' : String(resolved);
+      });
+    }
+
+    if (Array.isArray(node)) {
+      return node.map(item => this.applyIncludeParams(item, params));
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = this.applyIncludeParams(value, params);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private isIncludeDirective(value: unknown): value is { $include: { template: string; params?: Record<string, unknown> } } {
+    if (!this.isRecord(value) || !this.isRecord(value.$include)) {
+      return false;
+    }
+
+    return typeof value.$include.template === 'string';
   }
 
   /**

--- a/tests/unit/schema-include-validation.test.js
+++ b/tests/unit/schema-include-validation.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const Ajv = require('ajv');
+
+describe('Schema include validation', () => {
+  const loadJson = (relativePath) => {
+    const absolutePath = path.resolve(__dirname, '..', '..', relativePath);
+    return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  };
+
+  it('schema.json は components 内の $include を許可する', () => {
+    const schema = loadJson('schemas/schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate({
+      page: {
+        components: [
+          {
+            $include: {
+              template: './templates/header.template.yml',
+              params: {
+                title: 'hello'
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    assert.strictEqual(valid, true, JSON.stringify(validate.errors));
+  });
+
+  it('template-schema.json は配列ルートの $include を許可する', () => {
+    const schema = loadJson('schemas/template-schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate([
+      {
+        $include: {
+          template: './partials/field.template.yml'
+        }
+      }
+    ]);
+
+    assert.strictEqual(valid, true, JSON.stringify(validate.errors));
+  });
+
+  it('$include.template が無い場合は不正', () => {
+    const schema = loadJson('schemas/schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate({
+      page: {
+        components: [
+          {
+            $include: {
+              params: {
+                title: 'missing template path'
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    assert.strictEqual(valid, false);
+  });
+});

--- a/tests/unit/yaml-parser.test.js
+++ b/tests/unit/yaml-parser.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const os = require('os');
+const fs = require('fs');
 const Module = require('module');
 
 describe('YamlParser スキーマ検証', () => {
@@ -133,5 +135,58 @@ describe('YamlParser スキーマ検証', () => {
         return true;
       }
     );
+  });
+
+  it('$include で参照したテンプレートを解決し、ネストした参照も展開する', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-'));
+    const nestedTemplatePath = path.join(tmpDir, 'nested.template.yml');
+    const templatePath = path.join(tmpDir, 'form.template.yml');
+
+    fs.writeFileSync(nestedTemplatePath, `- Text:\n    variant: p\n    value: \"Nested: {{ $params.description }}\"\n`, 'utf8');
+    fs.writeFileSync(templatePath, `- Text:\n    variant: h2\n    value: \"{{ $params.title }}\"\n- $include:\n    template: \"./nested.template.yml\"\n    params:\n      description: \"{{ $params.description }}\"\n`, 'utf8');
+
+    const mainContent = `page:\n  components:\n    - $include:\n        template: \"./form.template.yml\"\n        params:\n          title: \"Hello\"\n          description: \"World\"\n`;
+
+    try {
+      setActiveEditor(mainContent);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'page.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+      const result = await parser.parseYamlFile();
+
+      assert.strictEqual(result.data.page.components[0].Text.value, 'Hello');
+      assert.strictEqual(result.data.page.components[1].Text.value, 'Nested: World');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('$include の循環参照を検出して YamlParseError を返す', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-cycle-'));
+    const templateAPath = path.join(tmpDir, 'a.template.yml');
+    const templateBPath = path.join(tmpDir, 'b.template.yml');
+
+    fs.writeFileSync(templateAPath, `- $include:\n    template: \"./b.template.yml\"\n`, 'utf8');
+    fs.writeFileSync(templateBPath, `- $include:\n    template: \"./a.template.yml\"\n`, 'utf8');
+
+    try {
+      setActiveEditor(`page:\n  components:\n    - $include:\n        template: \"./a.template.yml\"\n`);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'main.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+
+      await assert.rejects(
+        () => parser.parseYamlFile(),
+        (error) => {
+          assert.strictEqual(error.name, 'YamlParseError');
+          assert.match(error.message, /循環参照/);
+          return true;
+        }
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Add support for a template include directive so component lists can reference external templates and enable template composition. 
- Allow template-schema generation to reflect the new `$include` shape and let the YAML parser inline referenced templates before schema validation. 

### Description
- Extend `schemas/schema.json` and `schemas/template-schema.json` to allow an `includeDirective` (`$include`) as a possible item inside `components` and top-level template arrays. 
- Update `SchemaManager.createTemplateSchema` to use `definitions.componentArray.items` when present for generating `template-schema.json` via `items: schema.definitions.componentArray?.items ?? schema.definitions.component`. 
- Implement recursive include resolution in `src/services/webview/yaml-parser.ts` with `resolveTemplateIncludes`, `loadInclude`, and `applyIncludeParams`, supporting parameter interpolation (`{{ $params.xyz }}`) and detecting/guarding against cyclic includes. 
- Make the parser validate the fully-resolved YAML (after includes are expanded) against the loaded schema. 
- Add unit tests under `tests/unit/` for schema-level `$include` acceptance and YAML parser behaviors including nested include expansion and cycle detection. 

### Testing
- Added and ran `tests/unit/schema-include-validation.test.js` which verifies that `schema.json` and `template-schema.json` accept `$include` shapes and that missing `template` is rejected; the test passed. 
- Added and ran `tests/unit/yaml-parser.test.js` which verifies include expansion with nested templates and that cyclic includes raise `YamlParseError`; the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fd525a88832faa45e5d3878606f8)