### PR TITLE
feat: テーマの extends 継承（深いマージ・循環検出）を実装

### DIFF
--- a/schemas/theme-schema.json
+++ b/schemas/theme-schema.json
@@ -12,29 +12,49 @@
         "name": {
           "type": "string",
           "description": "テーマの名前",
-          "examples": ["Modern Blue Theme", "Corporate Theme", "Dark Mode"]
+          "examples": [
+            "Modern Blue Theme",
+            "Corporate Theme",
+            "Dark Mode"
+          ]
         },
         "version": {
           "type": "string",
           "description": "テーマのバージョン",
           "pattern": "^\\d+\\.\\d+\\.\\d+$",
-          "examples": ["1.0.0", "2.1.3"]
+          "examples": [
+            "1.0.0",
+            "2.1.3"
+          ]
         },
         "description": {
           "type": "string",
           "description": "テーマの説明",
-          "examples": ["モダンでクリーンなブルーベーステーマ"]
+          "examples": [
+            "モダンでクリーンなブルーベーステーマ"
+          ]
         },
         "author": {
           "type": "string",
           "description": "テーマの作成者",
-          "examples": ["TextUI Designer Team", "Your Name"]
+          "examples": [
+            "TextUI Designer Team",
+            "Your Name"
+          ]
+        },
+        "extends": {
+          "type": "string",
+          "description": "継承元テーマへの相対パス（MVP）",
+          "examples": [
+            "./base-theme.yml",
+            "../themes/corporate.yml"
+          ]
         },
         "tokens": {
           "type": "object",
           "description": "デザイントークン - カラー・スペーシング・タイポグラフィなどの基本設計要素",
           "properties": {
-            "color": { 
+            "color": {
               "type": "object",
               "description": "カラーパレット - ブランドカラーや状態色などの色定義",
               "properties": {
@@ -42,55 +62,83 @@
                   "type": "string",
                   "description": "メインブランドカラー - ボタンやリンクなどの主要要素で使用",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#3B82F6", "#1E40AF", "rgb(59, 130, 246)"]
+                  "examples": [
+                    "#3B82F6",
+                    "#1E40AF",
+                    "rgb(59, 130, 246)"
+                  ]
                 },
                 "secondary": {
                   "type": "string",
                   "description": "セカンダリカラー - 補助的な要素で使用",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#6B7280", "#64748B"]
+                  "examples": [
+                    "#6B7280",
+                    "#64748B"
+                  ]
                 },
                 "success": {
                   "type": "string",
                   "description": "成功状態を表すカラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#10B981", "#059669"]
+                  "examples": [
+                    "#10B981",
+                    "#059669"
+                  ]
                 },
                 "warning": {
                   "type": "string",
                   "description": "警告状態を表すカラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#F59E0B", "#D97706"]
+                  "examples": [
+                    "#F59E0B",
+                    "#D97706"
+                  ]
                 },
                 "error": {
                   "type": "string",
                   "description": "エラー状態を表すカラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#EF4444", "#DC2626"]
+                  "examples": [
+                    "#EF4444",
+                    "#DC2626"
+                  ]
                 },
                 "info": {
                   "type": "string",
                   "description": "情報表示用カラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#3B82F6", "#2563EB"]
+                  "examples": [
+                    "#3B82F6",
+                    "#2563EB"
+                  ]
                 },
                 "surface": {
                   "type": "string",
                   "description": "メイン背景カラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#F9FAFB", "#1F2937"]
+                  "examples": [
+                    "#F9FAFB",
+                    "#1F2937"
+                  ]
                 },
                 "background": {
                   "type": "string",
                   "description": "カード・コンテナの背景カラー",
                   "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                  "examples": ["#FFFFFF", "#111827"]
+                  "examples": [
+                    "#FFFFFF",
+                    "#111827"
+                  ]
                 },
                 "overlay": {
                   "type": "string",
                   "description": "オーバーレイ用カラー",
                   "pattern": "^rgba\\(|^hsla\\(",
-                  "examples": ["rgba(0, 0, 0, 0.5)", "rgba(255, 255, 255, 0.8)"]
+                  "examples": [
+                    "rgba(0, 0, 0, 0.5)",
+                    "rgba(255, 255, 255, 0.8)"
+                  ]
                 },
                 "text": {
                   "type": "object",
@@ -100,37 +148,55 @@
                       "type": "string",
                       "description": "主要テキストカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#111827", "#F9FAFB"]
+                      "examples": [
+                        "#111827",
+                        "#F9FAFB"
+                      ]
                     },
                     "secondary": {
                       "type": "string",
                       "description": "セカンダリテキストカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#6B7280", "#D1D5DB"]
+                      "examples": [
+                        "#6B7280",
+                        "#D1D5DB"
+                      ]
                     },
                     "muted": {
                       "type": "string",
                       "description": "控えめなテキストカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#9CA3AF", "#6B7280"]
+                      "examples": [
+                        "#9CA3AF",
+                        "#6B7280"
+                      ]
                     },
                     "inverse": {
                       "type": "string",
                       "description": "反転テキストカラー（ダーク背景用）",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#FFFFFF", "#111827"]
+                      "examples": [
+                        "#FFFFFF",
+                        "#111827"
+                      ]
                     },
                     "link": {
                       "type": "string",
                       "description": "リンクテキストカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#3B82F6", "#2563EB"]
+                      "examples": [
+                        "#3B82F6",
+                        "#2563EB"
+                      ]
                     },
                     "dark": {
                       "type": "string",
                       "description": "ダークテキストカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#000000", "#111827"]
+                      "examples": [
+                        "#000000",
+                        "#111827"
+                      ]
                     }
                   },
                   "additionalProperties": true
@@ -143,19 +209,28 @@
                       "type": "string",
                       "description": "デフォルトボーダーカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#E5E7EB", "#374151"]
+                      "examples": [
+                        "#E5E7EB",
+                        "#374151"
+                      ]
                     },
                     "focus": {
                       "type": "string",
                       "description": "フォーカス時のボーダーカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#3B82F6", "#2563EB"]
+                      "examples": [
+                        "#3B82F6",
+                        "#2563EB"
+                      ]
                     },
                     "error": {
                       "type": "string",
                       "description": "エラー時のボーダーカラー",
                       "pattern": "^#[0-9A-Fa-f]{6}$|^rgba?\\(|^hsl\\(",
-                      "examples": ["#EF4444", "#DC2626"]
+                      "examples": [
+                        "#EF4444",
+                        "#DC2626"
+                      ]
                     }
                   },
                   "additionalProperties": true
@@ -163,7 +238,7 @@
               },
               "additionalProperties": true
             },
-            "spacing": { 
+            "spacing": {
               "type": "object",
               "description": "スペーシングスケール - マージン・パディングなどの余白定義",
               "properties": {
@@ -171,48 +246,69 @@
                   "type": "string",
                   "description": "最小スペーシング（推奨: 4px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.25rem", "4px"]
+                  "examples": [
+                    "0.25rem",
+                    "4px"
+                  ]
                 },
                 "sm": {
                   "type": "string",
                   "description": "小スペーシング（推奨: 8px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.5rem", "8px"]
+                  "examples": [
+                    "0.5rem",
+                    "8px"
+                  ]
                 },
                 "md": {
                   "type": "string",
                   "description": "標準スペーシング（推奨: 16px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["1rem", "16px"]
+                  "examples": [
+                    "1rem",
+                    "16px"
+                  ]
                 },
                 "lg": {
                   "type": "string",
                   "description": "大スペーシング（推奨: 24px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["1.5rem", "24px"]
+                  "examples": [
+                    "1.5rem",
+                    "24px"
+                  ]
                 },
                 "xl": {
                   "type": "string",
                   "description": "最大スペーシング（推奨: 32px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["2rem", "32px"]
+                  "examples": [
+                    "2rem",
+                    "32px"
+                  ]
                 },
                 "2xl": {
                   "type": "string",
                   "description": "特大スペーシング（推奨: 48px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["3rem", "48px"]
+                  "examples": [
+                    "3rem",
+                    "48px"
+                  ]
                 },
                 "3xl": {
                   "type": "string",
                   "description": "超大スペーシング（推奨: 64px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["4rem", "64px"]
+                  "examples": [
+                    "4rem",
+                    "64px"
+                  ]
                 }
               },
               "additionalProperties": true
             },
-            "typography": { 
+            "typography": {
               "type": "object",
               "description": "タイポグラフィ設定 - フォント・サイズ・ウェイトなどの文字定義",
               "properties": {
@@ -221,7 +317,10 @@
                     {
                       "type": "string",
                       "description": "メインフォントファミリー",
-                      "examples": ["'Inter', 'Helvetica Neue', sans-serif", "'Roboto', Arial, sans-serif"]
+                      "examples": [
+                        "'Inter', 'Helvetica Neue', sans-serif",
+                        "'Roboto', Arial, sans-serif"
+                      ]
                     },
                     {
                       "type": "object",
@@ -230,12 +329,16 @@
                         "primary": {
                           "type": "string",
                           "description": "メインフォント",
-                          "examples": ["'Inter', 'Helvetica Neue', sans-serif"]
+                          "examples": [
+                            "'Inter', 'Helvetica Neue', sans-serif"
+                          ]
                         },
                         "monospace": {
                           "type": "string",
                           "description": "等幅フォント",
-                          "examples": ["'JetBrains Mono', 'Consolas', monospace"]
+                          "examples": [
+                            "'JetBrains Mono', 'Consolas', monospace"
+                          ]
                         }
                       },
                       "additionalProperties": true
@@ -250,49 +353,73 @@
                       "type": "string",
                       "description": "最小フォントサイズ（推奨: 12px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["0.75rem", "12px"]
+                      "examples": [
+                        "0.75rem",
+                        "12px"
+                      ]
                     },
                     "sm": {
                       "type": "string",
                       "description": "小フォントサイズ（推奨: 14px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["0.875rem", "14px"]
+                      "examples": [
+                        "0.875rem",
+                        "14px"
+                      ]
                     },
                     "base": {
                       "type": "string",
                       "description": "標準フォントサイズ（推奨: 16px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["1rem", "16px"]
+                      "examples": [
+                        "1rem",
+                        "16px"
+                      ]
                     },
                     "lg": {
                       "type": "string",
                       "description": "大フォントサイズ（推奨: 18px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["1.125rem", "18px"]
+                      "examples": [
+                        "1.125rem",
+                        "18px"
+                      ]
                     },
                     "xl": {
                       "type": "string",
                       "description": "特大フォントサイズ（推奨: 20px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["1.25rem", "20px"]
+                      "examples": [
+                        "1.25rem",
+                        "20px"
+                      ]
                     },
                     "2xl": {
                       "type": "string",
                       "description": "2倍大フォントサイズ（推奨: 24px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["1.5rem", "24px"]
+                      "examples": [
+                        "1.5rem",
+                        "24px"
+                      ]
                     },
                     "3xl": {
                       "type": "string",
                       "description": "3倍大フォントサイズ（推奨: 30px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["1.875rem", "30px"]
+                      "examples": [
+                        "1.875rem",
+                        "30px"
+                      ]
                     },
                     "4xl": {
                       "type": "string",
                       "description": "4倍大フォントサイズ（推奨: 36px）",
                       "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                      "examples": ["2.25rem", "36px"]
+                      "examples": [
+                        "2.25rem",
+                        "36px"
+                      ]
                     }
                   },
                   "additionalProperties": true
@@ -305,31 +432,46 @@
                       "type": "string",
                       "description": "軽いフォントウェイト",
                       "pattern": "^(light|[1-9]00)$",
-                      "examples": ["300", "light"]
+                      "examples": [
+                        "300",
+                        "light"
+                      ]
                     },
                     "normal": {
                       "type": "string",
                       "description": "標準フォントウェイト",
                       "pattern": "^(normal|[1-9]00)$",
-                      "examples": ["400", "normal"]
+                      "examples": [
+                        "400",
+                        "normal"
+                      ]
                     },
                     "medium": {
                       "type": "string",
                       "description": "中フォントウェイト",
                       "pattern": "^(medium|[1-9]00)$",
-                      "examples": ["500", "medium"]
+                      "examples": [
+                        "500",
+                        "medium"
+                      ]
                     },
                     "semibold": {
                       "type": "string",
                       "description": "セミボールドフォントウェイト",
                       "pattern": "^(semibold|[1-9]00)$",
-                      "examples": ["600", "semibold"]
+                      "examples": [
+                        "600",
+                        "semibold"
+                      ]
                     },
                     "bold": {
                       "type": "string",
                       "description": "ボールドフォントウェイト",
                       "pattern": "^(bold|[1-9]00)$",
-                      "examples": ["700", "bold"]
+                      "examples": [
+                        "700",
+                        "bold"
+                      ]
                     }
                   },
                   "additionalProperties": true
@@ -342,19 +484,28 @@
                       "type": "string",
                       "description": "狭い行間",
                       "pattern": "^\\d+(\\.\\d+)?$",
-                      "examples": ["1.25", "1.2"]
+                      "examples": [
+                        "1.25",
+                        "1.2"
+                      ]
                     },
                     "normal": {
                       "type": "string",
                       "description": "標準行間",
                       "pattern": "^\\d+(\\.\\d+)?$",
-                      "examples": ["1.5", "1.4"]
+                      "examples": [
+                        "1.5",
+                        "1.4"
+                      ]
                     },
                     "relaxed": {
                       "type": "string",
                       "description": "広い行間",
                       "pattern": "^\\d+(\\.\\d+)?$",
-                      "examples": ["1.75", "1.8"]
+                      "examples": [
+                        "1.75",
+                        "1.8"
+                      ]
                     }
                   },
                   "additionalProperties": true
@@ -362,7 +513,7 @@
               },
               "additionalProperties": true
             },
-            "borderRadius": { 
+            "borderRadius": {
               "type": "object",
               "description": "ボーダー半径設定 - 角丸の定義",
               "properties": {
@@ -370,48 +521,68 @@
                   "type": "string",
                   "description": "角丸なし",
                   "pattern": "^0$",
-                  "examples": ["0"]
+                  "examples": [
+                    "0"
+                  ]
                 },
                 "sm": {
                   "type": "string",
                   "description": "小角丸（推奨: 4px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.25rem", "4px"]
+                  "examples": [
+                    "0.25rem",
+                    "4px"
+                  ]
                 },
                 "md": {
                   "type": "string",
                   "description": "標準角丸（推奨: 6px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.375rem", "6px"]
+                  "examples": [
+                    "0.375rem",
+                    "6px"
+                  ]
                 },
                 "lg": {
                   "type": "string",
                   "description": "大角丸（推奨: 8px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.5rem", "8px"]
+                  "examples": [
+                    "0.5rem",
+                    "8px"
+                  ]
                 },
                 "xl": {
                   "type": "string",
                   "description": "特大角丸（推奨: 12px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["0.75rem", "12px"]
+                  "examples": [
+                    "0.75rem",
+                    "12px"
+                  ]
                 },
                 "2xl": {
                   "type": "string",
                   "description": "2倍大角丸（推奨: 16px）",
                   "pattern": "^\\d+(\\.\\d+)?(px|rem|em|%)$",
-                  "examples": ["1rem", "16px"]
+                  "examples": [
+                    "1rem",
+                    "16px"
+                  ]
                 },
                 "full": {
                   "type": "string",
                   "description": "完全な円形",
                   "pattern": "^(9999px|50%|100%)$",
-                  "examples": ["9999px", "50%"]
+                  "examples": [
+                    "9999px",
+                    "50%"
+                  ]
                 }
               },
               "additionalProperties": true
             },
-            "shadows": { 
+            "shadows": {
               "type": "object",
               "description": "シャドウ設定 - 奥行き表現の定義",
               "properties": {
@@ -419,25 +590,33 @@
                   "type": "string",
                   "description": "小シャドウ",
                   "pattern": "^\\d+",
-                  "examples": ["0 1px 2px 0 rgba(0, 0, 0, 0.05)"]
+                  "examples": [
+                    "0 1px 2px 0 rgba(0, 0, 0, 0.05)"
+                  ]
                 },
                 "md": {
                   "type": "string",
                   "description": "標準シャドウ",
                   "pattern": "^\\d+",
-                  "examples": ["0 4px 6px -1px rgba(0, 0, 0, 0.1)"]
+                  "examples": [
+                    "0 4px 6px -1px rgba(0, 0, 0, 0.1)"
+                  ]
                 },
                 "lg": {
                   "type": "string",
                   "description": "大シャドウ",
                   "pattern": "^\\d+",
-                  "examples": ["0 10px 15px -3px rgba(0, 0, 0, 0.1)"]
+                  "examples": [
+                    "0 10px 15px -3px rgba(0, 0, 0, 0.1)"
+                  ]
                 },
                 "xl": {
                   "type": "string",
                   "description": "特大シャドウ",
                   "pattern": "^\\d+",
-                  "examples": ["0 20px 25px -5px rgba(0, 0, 0, 0.1)"]
+                  "examples": [
+                    "0 20px 25px -5px rgba(0, 0, 0, 0.1)"
+                  ]
                 }
               },
               "additionalProperties": true
@@ -450,19 +629,28 @@
                   "type": "string",
                   "description": "高速トランジション",
                   "pattern": "^\\d+ms",
-                  "examples": ["150ms ease-in-out", "100ms ease"]
+                  "examples": [
+                    "150ms ease-in-out",
+                    "100ms ease"
+                  ]
                 },
                 "normal": {
                   "type": "string",
                   "description": "標準トランジション",
                   "pattern": "^\\d+ms",
-                  "examples": ["200ms ease-in-out", "250ms ease"]
+                  "examples": [
+                    "200ms ease-in-out",
+                    "250ms ease"
+                  ]
                 },
                 "slow": {
                   "type": "string",
                   "description": "低速トランジション",
                   "pattern": "^\\d+ms",
-                  "examples": ["300ms ease-in-out", "400ms ease"]
+                  "examples": [
+                    "300ms ease-in-out",
+                    "400ms ease"
+                  ]
                 }
               },
               "additionalProperties": true
@@ -672,9 +860,9 @@
               "additionalProperties": true
             },
             "container": {
-                  "type": "object",
+              "type": "object",
               "description": "コンテナコンポーネントのスタイル",
-                  "properties": {
+              "properties": {
                 "base": {
                   "$ref": "#/definitions/componentStyle",
                   "description": "基本コンテナのスタイル"
@@ -691,8 +879,8 @@
                   "$ref": "#/definitions/componentStyle",
                   "description": "カードスタイル"
                 }
-                  },
-                  "additionalProperties": true
+              },
+              "additionalProperties": true
             },
             "form": {
               "type": "object",
@@ -717,11 +905,12 @@
           "additionalProperties": true
         }
       },
-      "required": ["tokens"],
       "additionalProperties": true
     }
   },
-  "required": ["theme"],
+  "required": [
+    "theme"
+  ],
   "additionalProperties": false,
   "definitions": {
     "componentStyle": {
@@ -731,201 +920,371 @@
         "backgroundColor": {
           "type": "string",
           "description": "背景色",
-          "examples": ["var(--color-primary)", "#FFFFFF", "rgba(255, 255, 255, 0.8)"]
+          "examples": [
+            "var(--color-primary)",
+            "#FFFFFF",
+            "rgba(255, 255, 255, 0.8)"
+          ]
         },
         "color": {
           "type": "string",
           "description": "文字色",
-          "examples": ["var(--color-text-primary)", "#000000", "var(--color-text-inverse)"]
+          "examples": [
+            "var(--color-text-primary)",
+            "#000000",
+            "var(--color-text-inverse)"
+          ]
         },
         "padding": {
           "type": "string",
           "description": "パディング",
-          "examples": ["var(--spacing-md)", "16px", "1rem 2rem"]
+          "examples": [
+            "var(--spacing-md)",
+            "16px",
+            "1rem 2rem"
+          ]
         },
         "margin": {
           "type": "string",
           "description": "マージン",
-          "examples": ["var(--spacing-md)", "16px", "1rem 0"]
+          "examples": [
+            "var(--spacing-md)",
+            "16px",
+            "1rem 0"
+          ]
         },
         "border": {
           "type": "string",
           "description": "ボーダー",
-          "examples": ["1px solid var(--color-border-default)", "none", "2px solid #ccc"]
+          "examples": [
+            "1px solid var(--color-border-default)",
+            "none",
+            "2px solid #ccc"
+          ]
         },
         "borderRadius": {
           "type": "string",
           "description": "ボーダー半径",
-          "examples": ["var(--borderRadius-md)", "8px", "50%"]
+          "examples": [
+            "var(--borderRadius-md)",
+            "8px",
+            "50%"
+          ]
         },
         "borderColor": {
           "type": "string",
           "description": "ボーダー色",
-          "examples": ["var(--color-border-default)", "#E5E7EB"]
+          "examples": [
+            "var(--color-border-default)",
+            "#E5E7EB"
+          ]
         },
         "borderWidth": {
           "type": "string",
           "description": "ボーダー幅",
-          "examples": ["1px", "2px", "0"]
+          "examples": [
+            "1px",
+            "2px",
+            "0"
+          ]
         },
         "boxShadow": {
           "type": "string",
           "description": "ボックスシャドウ",
-          "examples": ["var(--shadows-md)", "0 4px 6px rgba(0,0,0,0.1)", "none"]
+          "examples": [
+            "var(--shadows-md)",
+            "0 4px 6px rgba(0,0,0,0.1)",
+            "none"
+          ]
         },
         "fontSize": {
           "type": "string",
           "description": "フォントサイズ",
-          "examples": ["var(--typography-fontSize-base)", "16px", "1rem"]
+          "examples": [
+            "var(--typography-fontSize-base)",
+            "16px",
+            "1rem"
+          ]
         },
         "fontFamily": {
           "type": "string",
           "description": "フォントファミリー",
-          "examples": ["var(--typography-fontFamily-primary)", "Arial, sans-serif"]
+          "examples": [
+            "var(--typography-fontFamily-primary)",
+            "Arial, sans-serif"
+          ]
         },
         "fontWeight": {
           "type": "string",
           "description": "フォントウェイト",
-          "examples": ["var(--typography-fontWeight-medium)", "bold", "400"]
+          "examples": [
+            "var(--typography-fontWeight-medium)",
+            "bold",
+            "400"
+          ]
         },
         "lineHeight": {
           "type": "string",
           "description": "行間",
-          "examples": ["var(--typography-lineHeight-normal)", "1.5", "24px"]
+          "examples": [
+            "var(--typography-lineHeight-normal)",
+            "1.5",
+            "24px"
+          ]
         },
         "textAlign": {
           "type": "string",
           "description": "テキスト配置",
-          "enum": ["left", "center", "right", "justify"],
-          "examples": ["left", "center", "right"]
+          "enum": [
+            "left",
+            "center",
+            "right",
+            "justify"
+          ],
+          "examples": [
+            "left",
+            "center",
+            "right"
+          ]
         },
         "cursor": {
           "type": "string",
           "description": "カーソル",
-          "examples": ["pointer", "default", "text"]
+          "examples": [
+            "pointer",
+            "default",
+            "text"
+          ]
         },
         "transition": {
           "type": "string",
           "description": "トランジション",
-          "examples": ["var(--transition-normal)", "all 0.2s ease", "color 0.15s ease-in-out"]
+          "examples": [
+            "var(--transition-normal)",
+            "all 0.2s ease",
+            "color 0.15s ease-in-out"
+          ]
         },
         "display": {
           "type": "string",
           "description": "表示タイプ",
-          "examples": ["flex", "block", "inline-block", "none"]
+          "examples": [
+            "flex",
+            "block",
+            "inline-block",
+            "none"
+          ]
         },
         "flexDirection": {
           "type": "string",
           "description": "フレックス方向",
-          "enum": ["row", "column", "row-reverse", "column-reverse"],
-          "examples": ["row", "column"]
+          "enum": [
+            "row",
+            "column",
+            "row-reverse",
+            "column-reverse"
+          ],
+          "examples": [
+            "row",
+            "column"
+          ]
         },
         "alignItems": {
           "type": "string",
           "description": "アイテム配置",
-          "examples": ["center", "flex-start", "flex-end", "stretch"]
+          "examples": [
+            "center",
+            "flex-start",
+            "flex-end",
+            "stretch"
+          ]
         },
         "justifyContent": {
           "type": "string",
           "description": "コンテンツ配置",
-          "examples": ["center", "flex-start", "flex-end", "space-between"]
+          "examples": [
+            "center",
+            "flex-start",
+            "flex-end",
+            "space-between"
+          ]
         },
         "gap": {
           "type": "string",
           "description": "ギャップ",
-          "examples": ["var(--spacing-md)", "16px", "1rem"]
+          "examples": [
+            "var(--spacing-md)",
+            "16px",
+            "1rem"
+          ]
         },
         "width": {
           "type": "string",
           "description": "幅",
-          "examples": ["100%", "200px", "auto"]
+          "examples": [
+            "100%",
+            "200px",
+            "auto"
+          ]
         },
         "height": {
           "type": "string",
           "description": "高さ",
-          "examples": ["auto", "100px", "2rem"]
+          "examples": [
+            "auto",
+            "100px",
+            "2rem"
+          ]
         },
         "minHeight": {
           "type": "string",
           "description": "最小高さ",
-          "examples": ["2rem", "50px", "auto"]
+          "examples": [
+            "2rem",
+            "50px",
+            "auto"
+          ]
         },
         "maxWidth": {
           "type": "string",
           "description": "最大幅",
-          "examples": ["100%", "500px", "none"]
+          "examples": [
+            "100%",
+            "500px",
+            "none"
+          ]
         },
         "marginTop": {
           "type": "string",
           "description": "上マージン",
-          "examples": ["var(--spacing-lg)", "24px", "0"]
+          "examples": [
+            "var(--spacing-lg)",
+            "24px",
+            "0"
+          ]
         },
         "marginBottom": {
           "type": "string",
           "description": "下マージン",
-          "examples": ["var(--spacing-lg)", "24px", "0"]
+          "examples": [
+            "var(--spacing-lg)",
+            "24px",
+            "0"
+          ]
         },
         "marginLeft": {
           "type": "string",
           "description": "左マージン",
-          "examples": ["var(--spacing-sm)", "8px", "auto"]
+          "examples": [
+            "var(--spacing-sm)",
+            "8px",
+            "auto"
+          ]
         },
         "marginRight": {
           "type": "string",
           "description": "右マージン",
-          "examples": ["var(--spacing-sm)", "8px", "auto"]
+          "examples": [
+            "var(--spacing-sm)",
+            "8px",
+            "auto"
+          ]
         },
         "paddingTop": {
           "type": "string",
           "description": "上パディング",
-          "examples": ["var(--spacing-lg)", "24px", "0"]
+          "examples": [
+            "var(--spacing-lg)",
+            "24px",
+            "0"
+          ]
         },
         "paddingBottom": {
           "type": "string",
           "description": "下パディング",
-          "examples": ["var(--spacing-lg)", "24px", "0"]
+          "examples": [
+            "var(--spacing-lg)",
+            "24px",
+            "0"
+          ]
         },
         "paddingLeft": {
           "type": "string",
           "description": "左パディング",
-          "examples": ["var(--spacing-sm)", "8px", "0"]
+          "examples": [
+            "var(--spacing-sm)",
+            "8px",
+            "0"
+          ]
         },
         "paddingRight": {
           "type": "string",
           "description": "右パディング",
-          "examples": ["var(--spacing-sm)", "8px", "0"]
+          "examples": [
+            "var(--spacing-sm)",
+            "8px",
+            "0"
+          ]
         },
         "accentColor": {
           "type": "string",
           "description": "アクセントカラー（チェックボックス・ラジオボタン用）",
-          "examples": ["var(--color-primary)", "#3B82F6"]
+          "examples": [
+            "var(--color-primary)",
+            "#3B82F6"
+          ]
         },
         "opacity": {
           "type": "string",
           "description": "透明度",
           "pattern": "^(0|0\\.[0-9]+|1)$",
-          "examples": ["1", "0.8", "0.5"]
+          "examples": [
+            "1",
+            "0.8",
+            "0.5"
+          ]
         },
         "textTransform": {
           "type": "string",
           "description": "テキスト変換",
-          "enum": ["none", "uppercase", "lowercase", "capitalize"],
-          "examples": ["none", "uppercase", "lowercase"]
+          "enum": [
+            "none",
+            "uppercase",
+            "lowercase",
+            "capitalize"
+          ],
+          "examples": [
+            "none",
+            "uppercase",
+            "lowercase"
+          ]
         },
         "letterSpacing": {
           "type": "string",
           "description": "文字間隔",
-          "examples": ["0.1em", "1px", "normal"]
+          "examples": [
+            "0.1em",
+            "1px",
+            "normal"
+          ]
         },
         "textDecoration": {
           "type": "string",
           "description": "テキスト装飾",
-          "examples": ["none", "underline", "line-through"]
+          "examples": [
+            "none",
+            "underline",
+            "line-through"
+          ]
         },
         "outline": {
           "type": "string",
           "description": "アウトライン",
-          "examples": ["none", "1px solid blue", "2px dotted red"]
+          "examples": [
+            "none",
+            "1px solid blue",
+            "2px dotted red"
+          ]
         }
       },
       "additionalProperties": true

--- a/src/services/theme-manager.ts
+++ b/src/services/theme-manager.ts
@@ -171,26 +171,13 @@ export class ThemeManager implements IThemeManager {
       return;
     }
     try {
-      const content = fs.readFileSync(this.themePath, 'utf-8');
-      console.log('[ThemeManager] theme file content length:', content.length);
-      
-      // YAMLパース処理を非同期で実行（ブロッキングを防ぐ）
-      const data = await new Promise<unknown>((resolve, reject) => {
-        setImmediate(() => {
-          try {
-            const parsed = YAML.parse(content);
-            resolve(parsed);
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
-      
+      const data = await this.resolveThemeDefinition(this.themePath);
+
       console.log('[ThemeManager] parsed theme data:', JSON.stringify(data, null, 2));
       await this.validateTheme(data);
       if (isThemeDefinition(data)) {
-        this.tokens = data.theme.tokens || this.defaultTokens;
-        this.components = data.theme.components || this.defaultComponents;
+        this.tokens = this.deepMerge(this.defaultTokens, data.theme.tokens || {}) as ThemeTokens;
+        this.components = this.deepMerge(this.defaultComponents, data.theme.components || {}) as ThemeComponents;
       } else {
         console.warn('[ThemeManager] テーマ定義の形式が不正なため、デフォルトを使用します');
         this.resetToDefaultTheme();
@@ -202,6 +189,78 @@ export class ThemeManager implements IThemeManager {
       console.error('[ThemeManager] failed to load theme, using default theme', err);
       this.resetToDefaultTheme();
     }
+  }
+
+  private async resolveThemeDefinition(themeFilePath: string, chain: string[] = []): Promise<unknown> {
+    const normalizedPath = path.resolve(themeFilePath);
+    if (chain.includes(normalizedPath)) {
+      throw new Error(`[ThemeManager] Circular theme inheritance detected: ${[...chain, normalizedPath].join(' -> ')}`);
+    }
+
+    if (!fs.existsSync(normalizedPath)) {
+      throw new Error(`[ThemeManager] Extended theme file not found: ${normalizedPath}`);
+    }
+
+    const content = fs.readFileSync(normalizedPath, 'utf-8');
+    console.log('[ThemeManager] theme file content length:', content.length, 'path:', normalizedPath);
+
+    const data = await new Promise<unknown>((resolve, reject) => {
+      setImmediate(() => {
+        try {
+          const parsed = YAML.parse(content);
+          resolve(parsed);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    if (!isThemeDefinition(data)) {
+      return data;
+    }
+
+    const extendsPath = typeof data.theme.extends === 'string' ? data.theme.extends.trim() : '';
+    if (!extendsPath) {
+      return data;
+    }
+
+    if (extendsPath.startsWith('npm:')) {
+      throw new Error(`[ThemeManager] Unsupported extends path: ${extendsPath}`);
+    }
+
+    const parentPath = path.resolve(path.dirname(normalizedPath), extendsPath);
+    const parentData = await this.resolveThemeDefinition(parentPath, [...chain, normalizedPath]);
+    if (!isThemeDefinition(parentData)) {
+      return data;
+    }
+
+    const mergedTheme = this.deepMerge(parentData.theme, data.theme);
+    return {
+      ...parentData,
+      ...data,
+      theme: mergedTheme
+    };
+  }
+
+  private deepMerge(base: unknown, override: unknown): unknown {
+    if (Array.isArray(base) || Array.isArray(override)) {
+      return override ?? base;
+    }
+
+    if (!this.isPlainObject(base) || !this.isPlainObject(override)) {
+      return override ?? base;
+    }
+
+    const result: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(override)) {
+      const baseValue = (base as Record<string, unknown>)[key];
+      result[key] = this.deepMerge(baseValue, value);
+    }
+    return result;
+  }
+
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
   }
 
   generateCSSVariables(): string {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -175,8 +175,9 @@ export interface ThemeDefinition {
   theme: {
     name: string;
     description?: string;
-    tokens: ThemeTokens;
-    components: ThemeComponents;
+    extends?: string;
+    tokens?: ThemeTokens;
+    components?: ThemeComponents;
   };
 }
 

--- a/tests/unit/theme-manager.test.js
+++ b/tests/unit/theme-manager.test.js
@@ -11,6 +11,7 @@ global.vscode = global.vscode || {};
 describe('ThemeManager', () => {
   let themeManager;
   let testThemePath;
+  let extraCleanupPaths;
 
   beforeEach(() => {
     // ファクトリからThemeManagerを作成
@@ -23,6 +24,8 @@ describe('ThemeManager', () => {
       global.ThemeManagerFactory = ThemeManagerFactory;
     }
     
+    extraCleanupPaths = [];
+
     themeManager = global.ThemeManagerFactory.createForTest(global.vscode, {
       extensionPath: __dirname + '/../../',
       workspacePath: __dirname + '/../../'
@@ -35,6 +38,13 @@ describe('ThemeManager', () => {
       themeManager._testHelpers.cleanupTestFile(testThemePath);
     }
     
+    const fs = require('fs');
+    for (const filePath of extraCleanupPaths || []) {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    }
+
     if (themeManager && themeManager._testHelpers) {
       themeManager._testHelpers.resetAllMocks();
       themeManager._testHelpers.restoreRequire();
@@ -148,6 +158,108 @@ describe('ThemeManager', () => {
     // デフォルトテーマが使用されている
     assert.ok(cssVariables.includes('--colors-primary'));
     assert.ok(cssVariables.includes('--spacing-md'));
+  });
+
+
+  it('extendsで親テーマを継承し、子テーマで上書きできる', async () => {
+    const fs = require('fs');
+    const path = require('path');
+    const workspaceRoot = path.join(__dirname, '../../');
+    const parentPath = path.join(workspaceRoot, 'parent-theme.yml');
+
+    const parentTheme = {
+      theme: {
+        tokens: {
+          colors: {
+            primary: { value: '#111111' },
+            secondary: { value: '#222222' }
+          },
+          spacing: {
+            md: { value: '1rem' }
+          }
+        },
+        components: {
+          button: {
+            primary: {
+              color: '#FFFFFF',
+              backgroundColor: '#111111'
+            }
+          }
+        }
+      }
+    };
+
+    const childTheme = {
+      theme: {
+        extends: './parent-theme.yml',
+        tokens: {
+          colors: {
+            primary: { value: '#FF0000' }
+          }
+        },
+        components: {
+          button: {
+            primary: {
+              backgroundColor: '#FF0000'
+            }
+          }
+        }
+      }
+    };
+
+    fs.writeFileSync(parentPath, JSON.stringify(parentTheme, null, 2));
+    extraCleanupPaths.push(parentPath);
+    testThemePath = themeManager._testHelpers.createTestThemeFile(childTheme);
+
+    await themeManager.loadTheme();
+    const cssVariables = themeManager.generateCSSVariables();
+
+    assert.ok(cssVariables.includes('--colors-primary: #FF0000'));
+    assert.ok(cssVariables.includes('--colors-secondary: #222222'));
+    assert.ok(cssVariables.includes('--spacing-md: 1rem'));
+    assert.ok(cssVariables.includes('--component-button-primary-backgroundColor: #FF0000'));
+    assert.ok(cssVariables.includes('--component-button-primary-color: #FFFFFF'));
+
+  });
+
+  it('循環参照の継承が検出された場合はデフォルトテーマにフォールバックする', async () => {
+    const fs = require('fs');
+    const path = require('path');
+    const workspaceRoot = path.join(__dirname, '../../');
+    const parentPath = path.join(workspaceRoot, 'parent-circular-theme.yml');
+
+    const parentTheme = {
+      theme: {
+        extends: './textui-theme.yml',
+        tokens: {
+          colors: {
+            secondary: { value: '#00FF00' }
+          }
+        }
+      }
+    };
+
+    const childTheme = {
+      theme: {
+        extends: './parent-circular-theme.yml',
+        tokens: {
+          colors: {
+            primary: { value: '#FF0000' }
+          }
+        }
+      }
+    };
+
+    fs.writeFileSync(parentPath, JSON.stringify(parentTheme, null, 2));
+    extraCleanupPaths.push(parentPath);
+    testThemePath = themeManager._testHelpers.createTestThemeFile(childTheme);
+
+    await themeManager.loadTheme();
+    const cssVariables = themeManager.generateCSSVariables();
+
+    assert.ok(cssVariables.includes('--colors-primary: #3B82F6'));
+    assert.ok(cssVariables.includes('--spacing-md: 1rem'));
+
   });
 
   describe('ファクトリパターンの検証', () => {


### PR DESCRIPTION
### Motivation

- 既存のテーマローダは単一ファイルの読み込みしかサポートしておらず、部分的に上書きする継承パターンが必要だったため、テーマの再利用性と保守性を向上させる目的で `extends` による継承を実装しました。

### Description

- `ThemeManager` に再帰的な継承解決処理 `resolveThemeDefinition` を追加し、親テーマを読み込んで子テーマと深いマージを行うようにしました。 
- マージ処理は `deepMerge` を導入してオブジェクトを深く結合し、配列は子で置換、非オブジェクト値は子優先で解決します。 
- 継承チェーンの循環参照を検出してエラー化し、`npm:` プレフィックス経由の参照は現時点で未対応として明示的にエラーを投げるようにしました。 
- 読み込み時にデフォルト値と最終テーマを `default <- resolved theme` でマージするように変更し、部分的にしか定義されていない子テーマでも不足分が補完されるようにしました。 
- 型定義を更新して `ThemeDefinition` に `extends?: string` を追加し、`tokens`/`components` を optional に変更しました。 
- スキーマ `schemas/theme-schema.json` に `theme.extends` を追加して継承を明示的にサポートしました。 
- ユニットテストを拡張して、親テーマ継承の上書き動作と循環継承フォールバックを検証するケースを追加しました (`tests/unit/theme-manager.test.js`)。 

### Testing

- 実行コマンドは `npm test`（`pretest` で `compile` + `lint` を含む）を実行しました。 
- すべてのユニットテストがパスし、テストスイートは成功（`221 passing` を含む全テストパス）しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a407273e20832f9a71bb2711af8fe6)