### PR TITLE
Add `$include` template directive, include resolution in YAML parser, and recursive theme discovery

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -1,305 +1,535 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://example.com/textui/v0/schema.json",
-    "title": "TextUI Designer DSL v0",
-    "description": "Minimum viable component set for TextUI Designer (v0).",
-    "type": "object",
-    "properties": {
-      "page": {
-        "type": "object",
-        "description": "Page-level metadataとトップレベルのUI要素",
-        "required": ["components"],
-        "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "layout": {
-            "type": "string",
-            "enum": ["vertical", "horizontal", "flex", "grid"]
-          },
-          "components": { "$ref": "#/definitions/componentArray" }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/textui/v0/schema.json",
+  "title": "TextUI Designer DSL v0",
+  "description": "Minimum viable component set for TextUI Designer (v0).",
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "object",
+      "description": "Page-level metadataとトップレベルのUI要素",
+      "required": [
+        "components"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string",
+          "enum": [
+            "vertical",
+            "horizontal",
+            "flex",
+            "grid"
+          ]
+        },
+        "components": {
+          "$ref": "#/definitions/componentArray"
         }
-      },
-      "components": { "$ref": "#/definitions/componentArray" }
-    },
-    "definitions": {
-      "componentArray": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/component" }
-      },
-      "component": {
-        "type": "object",
-        "description": "Tagged union of all v0 components",
-        "oneOf": [
-          { "$ref": "#/definitions/Text" },
-          { "$ref": "#/definitions/Input" },
-          { "$ref": "#/definitions/Button" },
-          { "$ref": "#/definitions/Form" },
-          { "$ref": "#/definitions/Checkbox" },
-          { "$ref": "#/definitions/Radio" },
-          { "$ref": "#/definitions/Select" },
-          { "$ref": "#/definitions/Divider" },
-          { "$ref": "#/definitions/Container" },
-          { "$ref": "#/definitions/Alert" }
-        ]
-      },
-  
-      "Text": {
-        "type": "object",
-        "required": ["Text"],
-        "properties": {
-          "Text": {
-            "type": "object",
-            "required": ["variant", "value"],
-            "properties": {
-              "variant": {
-                "type": "string",
-                "enum": ["h1", "h2", "h3", "p", "small", "caption"],
-                "description": "テキストの見た目（見出し・段落・注釈など）を指定します。"
-              },
-              "value": { "type": "string", "description": "表示するテキスト内容。" }
-            },
-            "additionalProperties": false,
-            "description": "テキスト（見出し・段落など）を表示するコンポーネント。\n利用可能な属性: variant, value"
-          }
-        },
-        "additionalProperties": false,
-        "description": "テキスト（見出し・段落など）を表示するコンポーネント。"
-      },
-  
-      "Input": {
-        "type": "object",
-        "required": ["Input"],
-        "properties": {
-          "Input": {
-            "type": "object",
-            "required": ["label", "name", "type"],
-            "properties": {
-              "label": { "type": "string", "description": "入力欄のラベル（表示名）。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "type": {
-                "type": "string",
-                "enum": ["text", "email", "password", "number", "multiline"],
-                "description": "入力欄の種類（テキスト・メール・パスワード・数値・複数行）。"
-              },
-              "required": { "type": "boolean", "default": false, "description": "必須入力かどうか。trueで必須。" },
-              "placeholder": { "type": "string", "description": "入力欄のプレースホルダー（薄い説明文）。" }
-            },
-            "additionalProperties": false,
-            "description": "テキスト入力用コンポーネント。\n利用可能な属性: label, name, type, required, placeholder"
-          }
-        },
-        "additionalProperties": false,
-        "description": "テキスト入力用コンポーネント。"
-      },
-  
-      "Button": {
-        "type": "object",
-        "required": ["Button"],
-        "properties": {
-          "Button": {
-            "type": "object",
-            "required": ["label"],
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["primary", "secondary", "submit"],
-                "default": "primary",
-                "description": "ボタンの種類（主ボタン・副ボタン・送信ボタン）。"
-              },
-              "label": { "type": "string", "description": "ボタンに表示するテキスト。" },
-              "submit": { "type": "boolean", "default": false, "description": "フォーム送信ボタンかどうか。" }
-            },
-            "additionalProperties": false,
-            "description": "ボタンコンポーネント。\n利用可能な属性: kind, label, submit"
-          }
-        },
-        "additionalProperties": false,
-        "description": "ボタンコンポーネント。"
-      },
-  
-      "Checkbox": {
-        "type": "object",
-        "required": ["Checkbox"],
-        "properties": {
-          "Checkbox": {
-            "type": "object",
-            "required": ["label", "name"],
-            "properties": {
-              "label": { "type": "string", "description": "チェックボックスのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "required": { "type": "boolean", "default": false, "description": "必須項目かどうか。" }
-            },
-            "additionalProperties": false,
-            "description": "チェックボックスコンポーネント。\n利用可能な属性: label, name, required"
-          }
-        },
-        "additionalProperties": false,
-        "description": "チェックボックスコンポーネント。"
-      },
-  
-      "Radio": {
-        "type": "object",
-        "required": ["Radio"],
-        "properties": {
-          "Radio": {
-            "type": "object",
-            "required": ["label", "name", "options"],
-            "properties": {
-              "label": { "type": "string", "description": "ラジオボタンのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "options": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["label", "value"],
-                  "properties": {
-                    "label": { "type": "string", "description": "選択肢の表示名。" },
-                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
-                  },
-                  "additionalProperties": false,
-                  "description": "ラジオボタンの選択肢。"
-                },
-                "minItems": 1,
-                "description": "選択肢の配列。"
-              }
-            },
-            "additionalProperties": false,
-            "description": "ラジオボタンコンポーネント。\n利用可能な属性: label, name, options"
-          }
-        },
-        "additionalProperties": false,
-        "description": "ラジオボタンコンポーネント。"
-      },
-  
-      "Select": {
-        "type": "object",
-        "required": ["Select"],
-        "properties": {
-          "Select": {
-            "type": "object",
-            "required": ["label", "name", "options"],
-            "properties": {
-              "label": { "type": "string", "description": "セレクトボックスのラベル。" },
-              "name": { "type": "string", "description": "フォーム送信時のname属性。" },
-              "options": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": ["label", "value"],
-                  "properties": {
-                    "label": { "type": "string", "description": "選択肢の表示名。" },
-                    "value": { "type": ["string", "number", "boolean"], "description": "選択肢の値。" }
-                  },
-                  "additionalProperties": false,
-                  "description": "セレクトボックスの選択肢。"
-                },
-                "minItems": 1,
-                "description": "選択肢の配列。"
-              },
-              "multiple": { "type": "boolean", "default": false, "description": "複数選択を許可するか。" },
-              "placeholder": { "type": "string", "description": "セレクトボックスのプレースホルダー（未選択時の表示）。" }
-            },
-            "additionalProperties": false,
-            "description": "セレクトボックスコンポーネント。\n利用可能な属性: label, name, options, multiple, placeholder"
-          }
-        },
-        "additionalProperties": false,
-        "description": "セレクトボックスコンポーネント。"
-      },
-  
-      "Divider": {
-        "type": "object",
-        "required": ["Divider"],
-        "properties": {
-          "Divider": {
-            "type": "object",
-            "properties": {
-              "orientation": {
-                "type": "string",
-                "enum": ["horizontal", "vertical"],
-                "default": "horizontal",
-                "description": "区切り線の向き（横・縦）。"
-              }
-            },
-            "additionalProperties": false,
-            "description": "区切り線コンポーネント。\n利用可能な属性: orientation"
-          }
-        },
-        "additionalProperties": false,
-        "description": "区切り線コンポーネント。"
-      },
-  
-      "Container": {
-        "type": "object",
-        "required": ["Container"],
-        "properties": {
-          "Container": {
-            "type": "object",
-            "properties": {
-              "layout": {
-                "type": "string",
-                "enum": ["vertical", "horizontal", "flex", "grid"],
-                "description": "子コンポーネントの配置方法。"
-              },
-              "components": { "$ref": "#/definitions/componentArray", "description": "子コンポーネントの配列。" }
-            },
-            "required": ["components"],
-            "additionalProperties": false,
-            "description": "レイアウト用コンテナコンポーネント。\n利用可能な属性: layout, components"
-          }
-        },
-        "additionalProperties": false,
-        "description": "レイアウト用コンテナコンポーネント。"
-      },
-  
-      "Alert": {
-        "type": "object",
-        "required": ["Alert"],
-        "properties": {
-          "Alert": {
-            "type": "object",
-            "required": ["variant", "message"],
-            "properties": {
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"],
-                "default": "info",
-                "description": "アラートの種類（情報・成功・警告・エラー）。"
-              },
-              "message": { "type": "string", "description": "表示するメッセージ内容。" }
-            },
-            "additionalProperties": false,
-            "description": "アラートコンポーネント。\n利用可能な属性: variant, message"
-          }
-        },
-        "additionalProperties": false,
-        "description": "アラートコンポーネント。"
-      },
-  
-      "Form": {
-        "type": "object",
-        "required": ["Form"],
-        "properties": {
-          "Form": {
-            "type": "object",
-            "properties": {
-              "id": { "type": "string", "description": "フォームのID。" },
-              "fields": { "$ref": "#/definitions/componentArray", "description": "フォーム内の入力フィールド群。" },
-              "actions": {
-                "type": "array",
-                "items": { "$ref": "#/definitions/Button" },
-                "description": "フォーム下部のボタン群。"
-              }
-            },
-            "required": ["fields"],
-            "additionalProperties": false,
-            "description": "フォームコンポーネント。\n利用可能な属性: id, fields, actions"
-          }
-        },
-        "additionalProperties": false,
-        "description": "フォームコンポーネント。"
       }
     },
-    "additionalProperties": false
-  }
-  
+    "components": {
+      "$ref": "#/definitions/componentArray"
+    }
+  },
+  "definitions": {
+    "componentArray": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/includeDirective"
+          }
+        ]
+      }
+    },
+    "component": {
+      "type": "object",
+      "description": "Tagged union of all v0 components",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Text"
+        },
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "$ref": "#/definitions/Button"
+        },
+        {
+          "$ref": "#/definitions/Form"
+        },
+        {
+          "$ref": "#/definitions/Checkbox"
+        },
+        {
+          "$ref": "#/definitions/Radio"
+        },
+        {
+          "$ref": "#/definitions/Select"
+        },
+        {
+          "$ref": "#/definitions/Divider"
+        },
+        {
+          "$ref": "#/definitions/Container"
+        },
+        {
+          "$ref": "#/definitions/Alert"
+        }
+      ]
+    },
+    "includeDirective": {
+      "type": "object",
+      "required": [
+        "$include"
+      ],
+      "properties": {
+        "$include": {
+          "type": "object",
+          "required": [
+            "template"
+          ],
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "参照するテンプレートファイルへの相対パス。"
+            },
+            "params": {
+              "type": "object",
+              "description": "テンプレートへ渡すパラメータ。",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "$include によるテンプレート参照。"
+    },
+    "Text": {
+      "type": "object",
+      "required": [
+        "Text"
+      ],
+      "properties": {
+        "Text": {
+          "type": "object",
+          "required": [
+            "variant",
+            "value"
+          ],
+          "properties": {
+            "variant": {
+              "type": "string",
+              "enum": [
+                "h1",
+                "h2",
+                "h3",
+                "p",
+                "small",
+                "caption"
+              ],
+              "description": "テキストの見た目（見出し・段落・注釈など）を指定します。"
+            },
+            "value": {
+              "type": "string",
+              "description": "表示するテキスト内容。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "テキスト（見出し・段落など）を表示するコンポーネント。\n利用可能な属性: variant, value"
+        }
+      },
+      "additionalProperties": false,
+      "description": "テキスト（見出し・段落など）を表示するコンポーネント。"
+    },
+    "Input": {
+      "type": "object",
+      "required": [
+        "Input"
+      ],
+      "properties": {
+        "Input": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "入力欄のラベル（表示名）。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "email",
+                "password",
+                "number",
+                "multiline"
+              ],
+              "description": "入力欄の種類（テキスト・メール・パスワード・数値・複数行）。"
+            },
+            "required": {
+              "type": "boolean",
+              "default": false,
+              "description": "必須入力かどうか。trueで必須。"
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "入力欄のプレースホルダー（薄い説明文）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "テキスト入力用コンポーネント。\n利用可能な属性: label, name, type, required, placeholder"
+        }
+      },
+      "additionalProperties": false,
+      "description": "テキスト入力用コンポーネント。"
+    },
+    "Button": {
+      "type": "object",
+      "required": [
+        "Button"
+      ],
+      "properties": {
+        "Button": {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "submit"
+              ],
+              "default": "primary",
+              "description": "ボタンの種類（主ボタン・副ボタン・送信ボタン）。"
+            },
+            "label": {
+              "type": "string",
+              "description": "ボタンに表示するテキスト。"
+            },
+            "submit": {
+              "type": "boolean",
+              "default": false,
+              "description": "フォーム送信ボタンかどうか。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "ボタンコンポーネント。\n利用可能な属性: kind, label, submit"
+        }
+      },
+      "additionalProperties": false,
+      "description": "ボタンコンポーネント。"
+    },
+    "Checkbox": {
+      "type": "object",
+      "required": [
+        "Checkbox"
+      ],
+      "properties": {
+        "Checkbox": {
+          "type": "object",
+          "required": [
+            "label",
+            "name"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "チェックボックスのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "required": {
+              "type": "boolean",
+              "default": false,
+              "description": "必須項目かどうか。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "チェックボックスコンポーネント。\n利用可能な属性: label, name, required"
+        }
+      },
+      "additionalProperties": false,
+      "description": "チェックボックスコンポーネント。"
+    },
+    "Radio": {
+      "type": "object",
+      "required": [
+        "Radio"
+      ],
+      "properties": {
+        "Radio": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "options"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "ラジオボタンのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "value"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "選択肢の表示名。"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ],
+                    "description": "選択肢の値。"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "ラジオボタンの選択肢。"
+              },
+              "minItems": 1,
+              "description": "選択肢の配列。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "ラジオボタンコンポーネント。\n利用可能な属性: label, name, options"
+        }
+      },
+      "additionalProperties": false,
+      "description": "ラジオボタンコンポーネント。"
+    },
+    "Select": {
+      "type": "object",
+      "required": [
+        "Select"
+      ],
+      "properties": {
+        "Select": {
+          "type": "object",
+          "required": [
+            "label",
+            "name",
+            "options"
+          ],
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "セレクトボックスのラベル。"
+            },
+            "name": {
+              "type": "string",
+              "description": "フォーム送信時のname属性。"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "value"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "選択肢の表示名。"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ],
+                    "description": "選択肢の値。"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "セレクトボックスの選択肢。"
+              },
+              "minItems": 1,
+              "description": "選択肢の配列。"
+            },
+            "multiple": {
+              "type": "boolean",
+              "default": false,
+              "description": "複数選択を許可するか。"
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "セレクトボックスのプレースホルダー（未選択時の表示）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "セレクトボックスコンポーネント。\n利用可能な属性: label, name, options, multiple, placeholder"
+        }
+      },
+      "additionalProperties": false,
+      "description": "セレクトボックスコンポーネント。"
+    },
+    "Divider": {
+      "type": "object",
+      "required": [
+        "Divider"
+      ],
+      "properties": {
+        "Divider": {
+          "type": "object",
+          "properties": {
+            "orientation": {
+              "type": "string",
+              "enum": [
+                "horizontal",
+                "vertical"
+              ],
+              "default": "horizontal",
+              "description": "区切り線の向き（横・縦）。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "区切り線コンポーネント。\n利用可能な属性: orientation"
+        }
+      },
+      "additionalProperties": false,
+      "description": "区切り線コンポーネント。"
+    },
+    "Container": {
+      "type": "object",
+      "required": [
+        "Container"
+      ],
+      "properties": {
+        "Container": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "type": "string",
+              "enum": [
+                "vertical",
+                "horizontal",
+                "flex",
+                "grid"
+              ],
+              "description": "子コンポーネントの配置方法。"
+            },
+            "components": {
+              "$ref": "#/definitions/componentArray",
+              "description": "子コンポーネントの配列。"
+            }
+          },
+          "required": [
+            "components"
+          ],
+          "additionalProperties": false,
+          "description": "レイアウト用コンテナコンポーネント。\n利用可能な属性: layout, components"
+        }
+      },
+      "additionalProperties": false,
+      "description": "レイアウト用コンテナコンポーネント。"
+    },
+    "Alert": {
+      "type": "object",
+      "required": [
+        "Alert"
+      ],
+      "properties": {
+        "Alert": {
+          "type": "object",
+          "required": [
+            "variant",
+            "message"
+          ],
+          "properties": {
+            "variant": {
+              "type": "string",
+              "enum": [
+                "info",
+                "success",
+                "warning",
+                "error"
+              ],
+              "default": "info",
+              "description": "アラートの種類（情報・成功・警告・エラー）。"
+            },
+            "message": {
+              "type": "string",
+              "description": "表示するメッセージ内容。"
+            }
+          },
+          "additionalProperties": false,
+          "description": "アラートコンポーネント。\n利用可能な属性: variant, message"
+        }
+      },
+      "additionalProperties": false,
+      "description": "アラートコンポーネント。"
+    },
+    "Form": {
+      "type": "object",
+      "required": [
+        "Form"
+      ],
+      "properties": {
+        "Form": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "フォームのID。"
+            },
+            "fields": {
+              "$ref": "#/definitions/componentArray",
+              "description": "フォーム内の入力フィールド群。"
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Button"
+              },
+              "description": "フォーム下部のボタン群。"
+            }
+          },
+          "required": [
+            "fields"
+          ],
+          "additionalProperties": false,
+          "description": "フォームコンポーネント。\n利用可能な属性: id, fields, actions"
+        }
+      },
+      "additionalProperties": false,
+      "description": "フォームコンポーネント。"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/template-schema.json
+++ b/schemas/template-schema.json
@@ -40,7 +40,14 @@
     "componentArray": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/component"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/includeDirective"
+          }
+        ]
       }
     },
     "component": {
@@ -78,6 +85,34 @@
           "$ref": "#/definitions/Alert"
         }
       ]
+    },
+    "includeDirective": {
+      "type": "object",
+      "required": [
+        "$include"
+      ],
+      "properties": {
+        "$include": {
+          "type": "object",
+          "required": [
+            "template"
+          ],
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "参照するテンプレートファイルへの相対パス。"
+            },
+            "params": {
+              "type": "object",
+              "description": "テンプレートへ渡すパラメータ。",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "$include によるテンプレート参照。"
     },
     "Text": {
       "type": "object",
@@ -490,38 +525,12 @@
   },
   "additionalProperties": false,
   "items": {
-    "type": "object",
-    "description": "Tagged union of all v0 components",
     "oneOf": [
       {
-        "$ref": "#/definitions/Text"
+        "$ref": "#/definitions/component"
       },
       {
-        "$ref": "#/definitions/Input"
-      },
-      {
-        "$ref": "#/definitions/Button"
-      },
-      {
-        "$ref": "#/definitions/Form"
-      },
-      {
-        "$ref": "#/definitions/Checkbox"
-      },
-      {
-        "$ref": "#/definitions/Radio"
-      },
-      {
-        "$ref": "#/definitions/Select"
-      },
-      {
-        "$ref": "#/definitions/Divider"
-      },
-      {
-        "$ref": "#/definitions/Container"
-      },
-      {
-        "$ref": "#/definitions/Alert"
+        "$ref": "#/definitions/includeDirective"
       }
     ]
   }

--- a/src/services/schema-manager.ts
+++ b/src/services/schema-manager.ts
@@ -91,18 +91,16 @@ export class SchemaManager implements ISchemaManager {
    * テンプレート用スキーマを生成
    */
   private async createTemplateSchema(): Promise<void> {
-    if (!fs.existsSync(this.templateSchemaPath)) {
-      try {
-        const schema = JSON.parse(fs.readFileSync(this.schemaPath, 'utf-8'));
-        const templateSchema = {
-          ...schema,
-          type: 'array',
-          items: schema.definitions.component
-        };
-        fs.writeFileSync(this.templateSchemaPath, JSON.stringify(templateSchema, null, 2), 'utf-8');
-      } catch (error) {
-        console.error('テンプレートスキーマの作成に失敗しました:', error);
-      }
+    try {
+      const schema = JSON.parse(fs.readFileSync(this.schemaPath, 'utf-8'));
+      const templateSchema = {
+        ...schema,
+        type: 'array',
+        items: schema.definitions.componentArray?.items ?? schema.definitions.component
+      };
+      fs.writeFileSync(this.templateSchemaPath, JSON.stringify(templateSchema, null, 2), 'utf-8');
+    } catch (error) {
+      console.error('テンプレートスキーマの作成に失敗しました:', error);
     }
   }
 

--- a/src/services/webview/webview-message-handler.ts
+++ b/src/services/webview/webview-message-handler.ts
@@ -205,60 +205,50 @@ export class WebViewMessageHandler {
     console.log('[WebViewMessageHandler] 現在のテーマパス:', currentThemePath);
     console.log('[WebViewMessageHandler] デフォルトテーマがアクティブ:', isDefaultThemeActive);
     
+    const discoveredPaths = new Set<string>();
+
     // 各ワークスペースフォルダでテーマファイルを検索
     for (const folder of workspaceFolders) {
       const folderPath = folder.uri.fsPath;
-      
-      // サンプルフォルダとルートディレクトリでテーマファイルを検索
-      const searchPaths = [
-        path.join(folderPath, 'sample'),
-        path.join(folderPath, 'textui-designer', 'sample'),
-        folderPath
-      ];
 
-      for (const searchPath of searchPaths) {
-        if (!fs.existsSync(searchPath)) {
+      const themeFiles = this.collectThemeFiles(folderPath);
+
+      for (const filePath of themeFiles) {
+        const normalizedPath = path.resolve(filePath);
+        if (discoveredPaths.has(normalizedPath)) {
           continue;
         }
+        discoveredPaths.add(normalizedPath);
 
-        const files = fs.readdirSync(searchPath);
-        const themeFiles = files.filter(file => 
-          file.endsWith('-theme.yml') || 
-          file.endsWith('_theme.yml') || 
-          file === 'textui-theme.yml'
-        );
+        const relativePath = path.relative(folderPath, filePath);
+        const fileName = path.basename(filePath);
 
-        for (const file of themeFiles) {
-          const filePath = path.join(searchPath, file);
-          const relativePath = path.relative(folderPath, filePath);
-          
-          // テーマファイルの内容を読み取って名前と説明を取得
-          try {
-            const content = fs.readFileSync(filePath, 'utf8');
-            const themeData = YAML.parse(content);
-            
-            const themeName = themeData?.theme?.name || file.replace(/(-theme|_theme)\.yml$/, '').replace(/\.yml$/, '');
-            const themeDescription = themeData?.theme?.description;
-            
-            // 現在のアクティブテーマかどうかを判定（パスの正規化で比較）
-            const isActive = Boolean(currentThemePath) &&
-              path.resolve(currentThemePath) === path.resolve(filePath);
+        // テーマファイルの内容を読み取って名前と説明を取得
+        try {
+          const content = fs.readFileSync(filePath, 'utf8');
+          const themeData = YAML.parse(content);
 
-            themes.push({
-              name: themeName,
-              path: relativePath,
-              isActive,
-              description: themeDescription
-            });
-          } catch (error) {
-            console.log(`[WebViewMessageHandler] テーマファイル読み取りエラー: ${filePath}`, error);
-            // エラーの場合はファイル名のみで追加
-            themes.push({
-              name: file.replace(/(-theme|_theme)\.yml$/, '').replace(/\.yml$/, ''),
-              path: relativePath,
-              isActive: false
-            });
-          }
+          const themeName = themeData?.theme?.name || fileName.replace(/(-theme|_theme)\.(ya?ml)$/, '').replace(/\.(ya?ml)$/, '');
+          const themeDescription = themeData?.theme?.description;
+
+          // 現在のアクティブテーマかどうかを判定（パスの正規化で比較）
+          const isActive = Boolean(currentThemePath) &&
+            path.resolve(currentThemePath) === path.resolve(filePath);
+
+          themes.push({
+            name: themeName,
+            path: relativePath,
+            isActive,
+            description: themeDescription
+          });
+        } catch (error) {
+          console.log(`[WebViewMessageHandler] テーマファイル読み取りエラー: ${filePath}`, error);
+          // エラーの場合はファイル名のみで追加
+          themes.push({
+            name: fileName.replace(/(-theme|_theme)\.(ya?ml)$/, '').replace(/\.(ya?ml)$/, ''),
+            path: relativePath,
+            isActive: false
+          });
         }
       }
     }
@@ -273,6 +263,54 @@ export class WebViewMessageHandler {
 
     console.log('[WebViewMessageHandler] 検出されたテーマ:', themes);
     return themes;
+  }
+
+  private collectThemeFiles(rootPath: string): string[] {
+    if (!fs.existsSync(rootPath)) {
+      return [];
+    }
+
+    const themeFiles: string[] = [];
+    const skipDirs = new Set(['.git', 'node_modules', 'out', 'media', '.next', 'dist', 'build']);
+    const stack: string[] = [rootPath];
+
+    while (stack.length > 0) {
+      const currentPath = stack.pop();
+      if (!currentPath) {
+        continue;
+      }
+
+      let entries: fs.Dirent[] = [];
+      try {
+        entries = fs.readdirSync(currentPath, { withFileTypes: true });
+      } catch (error) {
+        console.log(`[WebViewMessageHandler] ディレクトリ読み取りエラー: ${currentPath}`, error);
+        continue;
+      }
+
+      for (const entry of entries) {
+        const entryPath = path.join(currentPath, entry.name);
+        if (entry.isDirectory()) {
+          if (!skipDirs.has(entry.name)) {
+            stack.push(entryPath);
+          }
+          continue;
+        }
+
+        if (
+          entry.name.endsWith('-theme.yml') ||
+          entry.name.endsWith('-theme.yaml') ||
+          entry.name.endsWith('_theme.yml') ||
+          entry.name.endsWith('_theme.yaml') ||
+          entry.name === 'textui-theme.yml' ||
+          entry.name === 'textui-theme.yaml'
+        ) {
+          themeFiles.push(entryPath);
+        }
+      }
+    }
+
+    return themeFiles;
   }
 
   /**

--- a/src/services/webview/yaml-parser.ts
+++ b/src/services/webview/yaml-parser.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as YAML from 'yaml';
 import Ajv, { ErrorObject } from 'ajv';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { SchemaDefinition } from '../../types';
 import { PerformanceMonitor } from '../../utils/performance-monitor';
 import { ConfigManager } from '../../utils/config-manager';
@@ -74,12 +76,13 @@ export class YamlParser {
 
       // YAMLパース処理を非同期で実行
       const yaml = await this.parseYamlContent(yamlContent, fileName);
+      const resolvedYaml = await this.resolveTemplateIncludes(yaml, fileName, new Set<string>());
 
       // スキーマバリデーションを実行
-      await this.validateYamlSchema(yaml, yamlContent, fileName);
+      await this.validateYamlSchema(resolvedYaml, yamlContent, fileName);
 
       return {
-        data: yaml,
+        data: resolvedYaml,
         fileName: fileName,
         content: yamlContent
       };
@@ -105,6 +108,119 @@ export class YamlParser {
       console.error('[YamlParser] YAMLパースエラー:', parseError);
       throw this.createParseError(parseError, yamlContent, fileName);
     }
+  }
+
+  /**
+   * $include を再帰的に解決
+   */
+  private async resolveTemplateIncludes(node: unknown, currentFile: string, includeStack: Set<string>): Promise<unknown> {
+    if (Array.isArray(node)) {
+      const resolvedItems: unknown[] = [];
+
+      for (const item of node) {
+        if (this.isIncludeDirective(item)) {
+          const included = await this.loadInclude(item.$include, currentFile, includeStack);
+          const flattened = Array.isArray(included) ? included : [included];
+          resolvedItems.push(...flattened);
+          continue;
+        }
+
+        resolvedItems.push(await this.resolveTemplateIncludes(item, currentFile, includeStack));
+      }
+
+      return resolvedItems;
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = await this.resolveTemplateIncludes(value, currentFile, includeStack);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private async loadInclude(
+    includeSpec: { template: string; params?: Record<string, unknown> },
+    currentFile: string,
+    includeStack: Set<string>
+  ): Promise<unknown> {
+    const baseDir = path.dirname(currentFile);
+    const includePath = path.resolve(baseDir, includeSpec.template);
+
+    if (includeStack.has(includePath)) {
+      const error = new Error(`循環参照を検出しました: ${[...includeStack, includePath].join(' -> ')}`);
+      error.name = 'YamlParseError';
+      throw error;
+    }
+
+    includeStack.add(includePath);
+
+    try {
+      const includeContent = await fs.readFile(includePath, 'utf-8');
+      const includeYaml = await this.parseYamlContent(includeContent, includePath);
+      const withParams = this.applyIncludeParams(includeYaml, includeSpec.params ?? {});
+
+      return await this.resolveTemplateIncludes(withParams, includePath, includeStack);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'YamlParseError') {
+        throw error;
+      }
+
+      const fileError = new Error(`テンプレート読み込みに失敗しました: ${includeSpec.template} (${String(error)})`);
+      fileError.name = 'YamlParseError';
+      throw fileError;
+    } finally {
+      includeStack.delete(includePath);
+    }
+  }
+
+  private applyIncludeParams(node: unknown, params: Record<string, unknown>): unknown {
+    if (typeof node === 'string') {
+      return node.replace(/\{\{\s*\$params\.([\w.]+)\s*\}\}/g, (_match, expression: string) => {
+        const resolved = expression.split('.').reduce<unknown>((acc, key) => {
+          if (!this.isRecord(acc)) {
+            return undefined;
+          }
+
+          return acc[key];
+        }, params);
+
+        return resolved === undefined || resolved === null ? '' : String(resolved);
+      });
+    }
+
+    if (Array.isArray(node)) {
+      return node.map(item => this.applyIncludeParams(item, params));
+    }
+
+    if (this.isRecord(node)) {
+      const resolvedObject: Record<string, unknown> = {};
+
+      for (const [key, value] of Object.entries(node)) {
+        resolvedObject[key] = this.applyIncludeParams(value, params);
+      }
+
+      return resolvedObject;
+    }
+
+    return node;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private isIncludeDirective(value: unknown): value is { $include: { template: string; params?: Record<string, unknown> } } {
+    if (!this.isRecord(value) || !this.isRecord(value.$include)) {
+      return false;
+    }
+
+    return typeof value.$include.template === 'string';
   }
 
   /**

--- a/tests/integration/theme-switching.test.js
+++ b/tests/integration/theme-switching.test.js
@@ -15,6 +15,8 @@ describe('テーマ切り替え機能 結合テスト', () => {
   const emittedMessages = [];
   const mockThemeManager = {
     themePath: '',
+    getThemePath() { return this.themePath; },
+    setThemePath(themePath) { this.themePath = themePath; },
     loadTheme: async () => {},
     generateCSSVariables: () => '--mock-theme-var: 1;'
   };
@@ -51,10 +53,13 @@ describe('テーマ切り替え機能 結合テスト', () => {
 
     testWorkspaceDir = path.join(__dirname, '../fixtures/theme-integration-test');
     const sampleDir = path.join(testWorkspaceDir, 'sample');
+    const nestedThemeDir = path.join(sampleDir, 'nested', 'themes');
     fs.mkdirSync(sampleDir, { recursive: true });
+    fs.mkdirSync(nestedThemeDir, { recursive: true });
 
     const theme1Path = path.join(sampleDir, 'integration-one-theme.yml');
     const theme2Path = path.join(sampleDir, 'integration-two-theme.yml');
+    const nestedThemePath = path.join(nestedThemeDir, 'integration-nested-theme.yml');
 
     fs.writeFileSync(theme1Path, `theme:
   name: "Integration Theme One"
@@ -69,7 +74,14 @@ describe('テーマ切り替え機能 結合テスト', () => {
     color:
       primary: "#FF6B6B"`);
 
-    testThemeFiles = [theme1Path, theme2Path];
+    fs.writeFileSync(nestedThemePath, `theme:
+  name: "Integration Nested Theme"
+  description: "Nested directory theme"
+  tokens:
+    color:
+      primary: "#7C3AED"`);
+
+    testThemeFiles = [theme1Path, theme2Path, nestedThemePath];
     emittedMessages.length = 0;
 
     webviewManager = global.WebViewManagerFactory.createForTest(global.vscode, {
@@ -131,6 +143,7 @@ describe('テーマ切り替え機能 結合テスト', () => {
     assert.ok(names.includes('デフォルト'), 'デフォルトテーマが含まれる');
     assert.ok(names.includes('Integration Theme One'), '追加テーマ1が検出される');
     assert.ok(names.includes('Integration Theme Two'), '追加テーマ2が検出される');
+    assert.ok(names.includes('Integration Nested Theme'), 'ネストディレクトリのテーマが検出される');
   });
 
   it('theme-switchでCSS適用とアクティブテーマ更新が行われる', async () => {

--- a/tests/unit/schema-include-validation.test.js
+++ b/tests/unit/schema-include-validation.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const Ajv = require('ajv');
+
+describe('Schema include validation', () => {
+  const loadJson = (relativePath) => {
+    const absolutePath = path.resolve(__dirname, '..', '..', relativePath);
+    return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  };
+
+  it('schema.json は components 内の $include を許可する', () => {
+    const schema = loadJson('schemas/schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate({
+      page: {
+        components: [
+          {
+            $include: {
+              template: './templates/header.template.yml',
+              params: {
+                title: 'hello'
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    assert.strictEqual(valid, true, JSON.stringify(validate.errors));
+  });
+
+  it('template-schema.json は配列ルートの $include を許可する', () => {
+    const schema = loadJson('schemas/template-schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate([
+      {
+        $include: {
+          template: './partials/field.template.yml'
+        }
+      }
+    ]);
+
+    assert.strictEqual(valid, true, JSON.stringify(validate.errors));
+  });
+
+  it('$include.template が無い場合は不正', () => {
+    const schema = loadJson('schemas/schema.json');
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const valid = validate({
+      page: {
+        components: [
+          {
+            $include: {
+              params: {
+                title: 'missing template path'
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    assert.strictEqual(valid, false);
+  });
+});

--- a/tests/unit/yaml-parser.test.js
+++ b/tests/unit/yaml-parser.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const os = require('os');
+const fs = require('fs');
 const Module = require('module');
 
 describe('YamlParser スキーマ検証', () => {
@@ -133,5 +135,58 @@ describe('YamlParser スキーマ検証', () => {
         return true;
       }
     );
+  });
+
+  it('$include で参照したテンプレートを解決し、ネストした参照も展開する', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-'));
+    const nestedTemplatePath = path.join(tmpDir, 'nested.template.yml');
+    const templatePath = path.join(tmpDir, 'form.template.yml');
+
+    fs.writeFileSync(nestedTemplatePath, `- Text:\n    variant: p\n    value: \"Nested: {{ $params.description }}\"\n`, 'utf8');
+    fs.writeFileSync(templatePath, `- Text:\n    variant: h2\n    value: \"{{ $params.title }}\"\n- $include:\n    template: \"./nested.template.yml\"\n    params:\n      description: \"{{ $params.description }}\"\n`, 'utf8');
+
+    const mainContent = `page:\n  components:\n    - $include:\n        template: \"./form.template.yml\"\n        params:\n          title: \"Hello\"\n          description: \"World\"\n`;
+
+    try {
+      setActiveEditor(mainContent);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'page.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+      const result = await parser.parseYamlFile();
+
+      assert.strictEqual(result.data.page.components[0].Text.value, 'Hello');
+      assert.strictEqual(result.data.page.components[1].Text.value, 'Nested: World');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('$include の循環参照を検出して YamlParseError を返す', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'textui-include-cycle-'));
+    const templateAPath = path.join(tmpDir, 'a.template.yml');
+    const templateBPath = path.join(tmpDir, 'b.template.yml');
+
+    fs.writeFileSync(templateAPath, `- $include:\n    template: \"./b.template.yml\"\n`, 'utf8');
+    fs.writeFileSync(templateBPath, `- $include:\n    template: \"./a.template.yml\"\n`, 'utf8');
+
+    try {
+      setActiveEditor(`page:\n  components:\n    - $include:\n        template: \"./a.template.yml\"\n`);
+      vscodeApi.window.activeTextEditor.document.fileName = path.join(tmpDir, 'main.tui.yml');
+
+      const parser = new YamlParser({ loadSchema: async () => ({ type: 'object' }) });
+      PerformanceMonitor.getInstance().setEnabled(false);
+
+      await assert.rejects(
+        () => parser.parseYamlFile(),
+        (error) => {
+          assert.strictEqual(error.name, 'YamlParseError');
+          assert.match(error.message, /循環参照/);
+          return true;
+        }
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Allow templates to include reusable fragments via a `$include` directive in component arrays and template roots to enable composition and parametrization of UI fragments.
- Resolve included templates (with parameter interpolation) during YAML parsing and detect circular includes to prevent infinite recursion.
- Improve theme discovery to recursively search workspace folders (including nested directories) and avoid duplicate entries.

### Description
- Extended `schemas/schema.json` and `schemas/template-schema.json` to add an `includeDirective` definition and permit `$include` objects inside `componentArray` and template array roots, and adjusted schema structure accordingly.
- Implemented recursive include resolution in `src/services/webview/yaml-parser.ts` by adding `resolveTemplateIncludes`, `loadInclude`, `applyIncludeParams`, and helper predicates, with cycle detection and parameter interpolation support; switched to `fs/promises` and `path` where appropriate.
- Updated `src/services/schema-manager.ts` to generate `template-schema.json` using `componentArray.items` when present (fallback to the previous `component` definition) to match the new schema layout.
- Enhanced theme detection in `src/services/webview/webview-message-handler.ts` by adding `collectThemeFiles` for recursive directory traversal, deduplicating discovered paths, improving filename matching (supporting `.yml`/`.yaml`), and making logging and relative path handling more robust.
- Added and updated tests: new `tests/unit/schema-include-validation.test.js`, extended `tests/unit/yaml-parser.test.js` with include resolution and cycle-detection scenarios, and updated `tests/integration/theme-switching.test.js` to assert detection of nested theme files.

### Testing
- Ran unit tests including `tests/unit/schema-include-validation.test.js` and `tests/unit/yaml-parser.test.js`, which validate schema acceptance of `$include`, include parameter interpolation, and cycle detection; these tests passed.
- Ran integration tests including `tests/integration/theme-switching.test.js` to verify recursive theme discovery and theme switching behavior; the updated integration test passed.
- Overall test suite (unit + integration) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fd525a88832faa45e5d3878606f8)