### PR TITLE
ドキュメントオープン時の診断を TextUI 関連ファイルのみに制限

### DIFF
--- a/src/services/event-manager.ts
+++ b/src/services/event-manager.ts
@@ -132,13 +132,40 @@ export class EventManager {
 
     const documentOpenDisposable = vscode.workspace.onDidOpenTextDocument(document => {
       const diagnosticSettings = ConfigManager.getDiagnosticSettings();
-      if (diagnosticSettings.enabled) {
+      if (diagnosticSettings.enabled && this.shouldValidateDocument(document.fileName)) {
         this.services!.diagnosticManager.validateAndReportDiagnostics(document);
       }
     });
     
     this.disposables.push(documentOpenDisposable);
     console.log('[EventManager] ドキュメントオープン監視を登録しました');
+  }
+
+  /**
+   * 診断対象ファイルかどうかを判定
+   */
+  private shouldValidateDocument(fileName: string): boolean {
+    const lower = fileName.toLowerCase();
+
+    if (ConfigManager.isSupportedFile(lower)) {
+      return true;
+    }
+
+    return (
+      /\.template\.(ya?ml|json)$/.test(lower) ||
+      lower.endsWith('-theme.yml') ||
+      lower.endsWith('-theme.yaml') ||
+      lower.endsWith('_theme.yml') ||
+      lower.endsWith('_theme.yaml') ||
+      lower.endsWith('/textui-theme.yml') ||
+      lower.endsWith('/textui-theme.yaml') ||
+      lower.endsWith('\\textui-theme.yml') ||
+      lower.endsWith('\\textui-theme.yaml') ||
+      lower.endsWith('-theme.json') ||
+      lower.endsWith('_theme.json') ||
+      lower.endsWith('/textui-theme.json') ||
+      lower.endsWith('\\textui-theme.json')
+    );
   }
 
   /**


### PR DESCRIPTION
### Motivation
- README.md 等の Markdown ファイルを開いた際に YAML スキーマ検証が誤って走りスキーマエラーを出してしまう問題を防ぐため、ドキュメントオープン時の診断を対象ファイルのみに制限します。

### Description
- `registerDocumentOpenHandler()` を更新して診断実行前に `shouldValidateDocument(document.fileName)` をチェックするようにしました。
- `shouldValidateDocument()` を追加し、`ConfigManager.isSupportedFile()` に合致する `.tui.yml/.tui.yaml`、`.template.(yml|yaml|json)`、および `*-theme.*` / `*_theme.*` / `textui-theme.*` 系ファイルのみ診断する判定を行うようにしました.

### Testing
- ビルドと型チェックを実行して `npm run compile` が成功しました。 
- Lint を実行して `npm run lint` が成功しました。 
- ユニットテストを実行して `npm run test:unit` が成功し既存のユニットテストはパスしました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a425ea5730832f8cca2197d9330e3b)