### PR TITLE
refactor: ExportManager を policy/state/observability/facade に分離

### DIFF
--- a/src/exporters/export-execution-facade.ts
+++ b/src/exporters/export-execution-facade.ts
@@ -1,0 +1,131 @@
+import type { NavigationFlowDSL, TextUIDSL } from '../domain/dsl-types';
+import { isNavigationFlowDSL } from '../domain/dsl-types';
+import type { ExportOptions } from './export-types';
+import type { ExportPipelineDeps, ExportWithDiffUpdateResult } from './export-pipeline';
+import { runOptimizedExport } from './export-pipeline';
+import type { ExportRoutePolicy } from './export-route-policy';
+import type { ExportSnapshotState } from './export-snapshot-state';
+import type { ExportObservabilityRecorder } from './export-observability-recorder';
+
+type FullRenderTrigger = 'direct' | 'fallback';
+
+interface ExportExecutionFacadeDeps {
+  routePolicy: ExportRoutePolicy;
+  snapshotState: ExportSnapshotState;
+  observability: ExportObservabilityRecorder;
+  pipelineDeps: () => ExportPipelineDeps;
+  runNavigationExporter: (dsl: NavigationFlowDSL, options: ExportOptions) => Promise<string>;
+  exportWithDiffUpdate: (dsl: TextUIDSL, options: ExportOptions) => Promise<ExportWithDiffUpdateResult>;
+}
+
+/**
+ * ExportManager から実行オーケストレーションを分離する facade。
+ */
+export class ExportExecutionFacade {
+  constructor(private readonly deps: ExportExecutionFacadeDeps) {}
+
+  async export(
+    dsl: TextUIDSL | NavigationFlowDSL,
+    options: ExportOptions
+  ): Promise<string> {
+    this.deps.observability.resetIncrementalDowngradeReason();
+
+    if (isNavigationFlowDSL(dsl)) {
+      return this.runMeasuredFullRender(dsl, options, 'direct');
+    }
+
+    const decisionStart = performance.now();
+    const decision = this.deps.routePolicy.decideIncrementalRoute(dsl, options);
+
+    if (!decision.shouldAttempt) {
+      if (decision.downgradeReason) {
+        this.deps.observability.markIncrementalDowngrade(decision.downgradeReason);
+        this.deps.observability.recordIncrementalRouteSample('incremental-diff', decisionStart, {
+          outcome: 'fallback',
+          failureKind: 'preflight'
+        });
+        return this.runMeasuredFullRender(dsl, options, 'fallback');
+      }
+      return this.runMeasuredFullRender(dsl, options, 'direct');
+    }
+
+    const incrementalResult = await this.tryIncrementalExport(
+      dsl,
+      options,
+      decisionStart,
+      decision.renderTargets ?? []
+    );
+    if (incrementalResult !== undefined) {
+      return incrementalResult;
+    }
+
+    return this.runMeasuredFullRender(dsl, options, 'fallback');
+  }
+
+  rememberSnapshotIfPossible(dsl: TextUIDSL | NavigationFlowDSL, sourcePath: string | undefined): void {
+    if (isNavigationFlowDSL(dsl) || !sourcePath) {
+      return;
+    }
+    this.deps.snapshotState.rememberSnapshot(sourcePath, dsl);
+  }
+
+  private async runMeasuredFullRender(
+    dsl: TextUIDSL | NavigationFlowDSL,
+    options: ExportOptions,
+    trigger: FullRenderTrigger
+  ): Promise<string> {
+    const startedAt = performance.now();
+    const result = isNavigationFlowDSL(dsl)
+      ? await this.deps.runNavigationExporter(dsl, options)
+      : await runOptimizedExport(dsl, options, this.deps.pipelineDeps());
+    this.deps.observability.recordIncrementalRouteSample('full-render', startedAt, {
+      trigger,
+      outcome: 'success'
+    });
+    return result;
+  }
+
+  private async tryIncrementalExport(
+    dsl: TextUIDSL,
+    options: ExportOptions,
+    startedAt: number,
+    renderTargets: ExportOptions['incrementalRenderTargets']
+  ): Promise<string | undefined> {
+    try {
+      const incrementalResult = await this.deps.exportWithDiffUpdate(dsl, {
+        ...options,
+        incrementalRenderTargets: renderTargets
+      });
+
+      if (!this.isValidIncrementalResult(incrementalResult)) {
+        this.deps.observability.markIncrementalDowngrade('invalid-incremental-result');
+        this.deps.observability.recordIncrementalRouteSample('incremental-diff', startedAt, {
+          outcome: 'fallback',
+          failureKind: 'invalid-result'
+        });
+        return undefined;
+      }
+
+      this.deps.observability.resetIncrementalDowngradeReason();
+      this.deps.observability.recordIncrementalRouteSample('incremental-diff', startedAt, {
+        outcome: 'success'
+      });
+      return incrementalResult.result;
+    } catch (error) {
+      this.deps.observability.markIncrementalDowngrade(
+        `incremental-route-error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.deps.observability.recordIncrementalRouteSample('incremental-diff', startedAt, {
+        outcome: 'fallback',
+        failureKind: 'execution-error'
+      });
+      return undefined;
+    }
+  }
+
+  private isValidIncrementalResult(result: ExportWithDiffUpdateResult): boolean {
+    return typeof result.result === 'string'
+      && result.result.length > 0
+      && Array.isArray(result.changedComponents);
+  }
+}

--- a/src/exporters/export-manager.ts
+++ b/src/exporters/export-manager.ts
@@ -1,5 +1,4 @@
 import type { NavigationFlowDSL, TextUIDSL } from '../domain/dsl-types';
-import { isNavigationFlowDSL } from '../domain/dsl-types';
 import { loadDslWithIncludesFromPath } from '../dsl/load-dsl-with-includes';
 import { CacheManager } from '../utils/cache-manager';
 import { DiffManager } from './metrics/diff-manager';
@@ -7,17 +6,15 @@ import { PerformanceMonitor } from '../utils/performance-monitor';
 import { ConfigManager } from '../utils/config-manager';
 import type { ExportOptions, Exporter } from './export-types';
 import { populateBuiltInExporters } from './built-in-exporter-registry';
-import type { ExportPipelineDeps } from './export-pipeline';
+import type { ExportPipelineDeps, ExportWithDiffUpdateResult } from './export-pipeline';
 import { runExportWithDiffUpdate, runOptimizedExport } from './export-pipeline';
 import { runBatchExport } from './export-batch';
 import { createPerformanceMonitorExportObserver } from './export-metrics-observer';
-import {
-  buildRenderTargetsFromDiffResult,
-  createDiffResultSkeleton,
-  createNormalizedDiffDocument,
-  type DiffRenderTarget
-} from '../core/textui-core-diff';
 import { Logger } from '../utils/logger';
+import { ExportRoutePolicy } from './export-route-policy';
+import { ExportSnapshotState } from './export-snapshot-state';
+import { ExportObservabilityRecorder } from './export-observability-recorder';
+import { ExportExecutionFacade } from './export-execution-facade';
 
 /**
  * ユーザー向けの export 結果を組み立てる **本流**（ファイル読込・形式に応じた `Exporter`・`CacheManager`）と、
@@ -28,14 +25,13 @@ import { Logger } from '../utils/logger';
  */
 export class ExportManager {
   private exporters: Map<string, Exporter> = new Map();
-  private cacheManager: CacheManager;
-  private diffManager: DiffManager;
-  private performanceMonitor: PerformanceMonitor;
+  private readonly cacheManager: CacheManager;
+  private readonly diffManager: DiffManager;
+  private readonly performanceMonitor: PerformanceMonitor;
   private readonly maxConcurrentOperations: number;
-  private readonly exportSnapshots = new Map<string, TextUIDSL>();
-  private readonly logger = new Logger('ExportManager');
-  /** Last reason incremental route was downgraded to full rerender. Exposed for future observability. */
-  lastIncrementalDowngradeReason: string | null = null;
+  private readonly snapshotState: ExportSnapshotState;
+  private readonly observability: ExportObservabilityRecorder;
+  private readonly executionFacade: ExportExecutionFacade;
 
   constructor() {
     populateBuiltInExporters(this.exporters);
@@ -50,7 +46,27 @@ export class ExportManager {
 
     this.diffManager = new DiffManager();
     this.performanceMonitor = PerformanceMonitor.getInstance();
+    this.snapshotState = new ExportSnapshotState();
+    const routePolicy = new ExportRoutePolicy(this.snapshotState);
+    const logger = new Logger('ExportManager');
+    this.observability = new ExportObservabilityRecorder(this.performanceMonitor, logger);
+    this.executionFacade = new ExportExecutionFacade({
+      routePolicy,
+      snapshotState: this.snapshotState,
+      observability: this.observability,
+      pipelineDeps: () => this.pipelineDeps(),
+      runNavigationExporter: (dsl, options) => this.runNavigationExporter(dsl, options),
+      exportWithDiffUpdate: (dsl, options) => this.exportWithDiffUpdate(dsl, options)
+    });
 
+  }
+
+  get lastIncrementalDowngradeReason(): string | null {
+    return this.observability.lastIncrementalDowngradeReason;
+  }
+
+  set lastIncrementalDowngradeReason(reason: string | null) {
+    this.observability.setLastIncrementalDowngradeReason(reason);
   }
 
   private pipelineDeps(): ExportPipelineDeps {
@@ -89,111 +105,13 @@ export class ExportManager {
           ...options,
           sourcePath: options.sourcePath ?? filePath
         };
-        this.lastIncrementalDowngradeReason = null;
-
-        let result: string;
-        if (!isNavigationFlowDSL(dsl) && this.shouldAttemptIncrementalRoute(normalizedOptions)) {
-          const incrementalDecisionStart = performance.now();
-          const incrementalTargets = this.buildIncrementalRenderTargets(dsl, normalizedOptions);
-          if (incrementalTargets) {
-            const incrementalResult = await this.tryIncrementalExport(
-              dsl,
-              normalizedOptions,
-              incrementalTargets,
-              incrementalDecisionStart
-            );
-            if (incrementalResult !== undefined) {
-              result = incrementalResult;
-            } else {
-              result = await this.runMeasuredFullRender(dsl, normalizedOptions, 'fallback');
-            }
-          } else {
-            this.recordIncrementalFallbackSample(incrementalDecisionStart, 'preflight');
-            result = await this.runMeasuredFullRender(dsl, normalizedOptions, 'fallback');
-          }
-        } else {
-          result = await this.runMeasuredFullRender(dsl, normalizedOptions, 'direct');
-        }
-
-        if (normalizedOptions.sourcePath && !isNavigationFlowDSL(dsl)) {
-          this.exportSnapshots.set(normalizedOptions.sourcePath, dsl);
-        }
+        const result = await this.executionFacade.export(dsl, normalizedOptions);
+        this.executionFacade.rememberSnapshotIfPossible(dsl, normalizedOptions.sourcePath);
         return result;
       } catch (error) {
         throw new Error(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     });
-  }
-
-  private isValidIncrementalResult(result: {
-    result: string;
-    isFullUpdate: boolean;
-    changedComponents: number[];
-  }): boolean {
-    return typeof result.result === 'string' && result.result.length > 0 && Array.isArray(result.changedComponents);
-  }
-
-  private async tryIncrementalExport(
-    dsl: TextUIDSL,
-    options: ExportOptions,
-    incrementalTargets: DiffRenderTarget[],
-    startedAt: number
-  ): Promise<string | undefined> {
-    try {
-      const incrementalResult = await this.exportWithDiffUpdate(dsl, {
-        ...options,
-        incrementalRenderTargets: incrementalTargets
-      });
-
-      if (!this.isValidIncrementalResult(incrementalResult)) {
-        const reason = 'invalid-incremental-result';
-        this.lastIncrementalDowngradeReason = reason;
-        this.recordIncrementalFallbackSample(startedAt, 'invalid-result');
-        this.logger.warn(`Incremental route downgraded to full rerender - ${reason}`);
-        return undefined;
-      }
-
-      this.lastIncrementalDowngradeReason = null;
-      this.performanceMonitor.recordIncrementalRouteSample(
-        'incremental-diff',
-        performance.now() - startedAt,
-        { outcome: 'success' }
-      );
-      return incrementalResult.result;
-    } catch (error) {
-      const reason = `incremental-route-error: ${error instanceof Error ? error.message : String(error)}`;
-      this.lastIncrementalDowngradeReason = reason;
-      this.recordIncrementalFallbackSample(startedAt, 'execution-error');
-      this.logger.warn(`Incremental route downgraded to full rerender - ${reason}`);
-      return undefined;
-    }
-  }
-
-  private shouldAttemptIncrementalRoute(options: ExportOptions): boolean {
-    return options.enableIncrementalDiffRoute === true
-      && !!options.sourcePath
-      && this.exportSnapshots.has(options.sourcePath);
-  }
-
-  private async runMeasuredFullRender(
-    dsl: TextUIDSL | NavigationFlowDSL,
-    options: ExportOptions,
-    trigger: 'direct' | 'fallback'
-  ): Promise<string> {
-    const startedAt = performance.now();
-    const result = isNavigationFlowDSL(dsl)
-      ? await this.runNavigationExporter(dsl, options)
-      : await runOptimizedExport(dsl, options, this.pipelineDeps());
-    this.performanceMonitor.recordIncrementalRouteSample(
-      'full-render',
-      performance.now() - startedAt,
-      {
-        trigger,
-        outcome: 'success',
-        fallbackReason: trigger === 'fallback' ? this.lastIncrementalDowngradeReason : undefined
-      }
-    );
-    return result;
   }
 
   private async runNavigationExporter(dsl: NavigationFlowDSL, options: ExportOptions): Promise<string> {
@@ -204,76 +122,13 @@ export class ExportManager {
     return exporter.export(dsl, options);
   }
 
-  private recordIncrementalFallbackSample(
-    startedAt: number,
-    failureKind: 'preflight' | 'execution-error' | 'invalid-result'
-  ): void {
-    this.performanceMonitor.recordIncrementalRouteSample(
-      'incremental-diff',
-      performance.now() - startedAt,
-      {
-        outcome: 'fallback',
-        failureKind,
-        fallbackReason: this.lastIncrementalDowngradeReason
-      }
-    );
-  }
-
-  private buildIncrementalRenderTargets(
-    dsl: TextUIDSL,
-    options: ExportOptions
-  ): DiffRenderTarget[] | undefined {
-    const sourcePath = options.sourcePath;
-    if (options.enableIncrementalDiffRoute !== true || !sourcePath) {
-      return undefined;
-    }
-    const previousDsl = this.exportSnapshots.get(sourcePath);
-    if (!previousDsl) {
-      return undefined;
-    }
-
-    let renderTargets: DiffRenderTarget[];
-    try {
-      const previous = createNormalizedDiffDocument(previousDsl, { side: 'previous', sourcePath });
-      const next = createNormalizedDiffDocument(dsl, { side: 'next', sourcePath });
-      renderTargets = buildRenderTargetsFromDiffResult(createDiffResultSkeleton(previous, next));
-    } catch (error) {
-      const reason = `diff-computation-error: ${error instanceof Error ? error.message : String(error)}`;
-      this.lastIncrementalDowngradeReason = reason;
-      this.logger.warn(`Incremental route downgraded to full rerender — ${reason}`);
-      return undefined;
-    }
-
-    if (renderTargets.length === 0) {
-      const reason = 'empty-render-targets';
-      this.lastIncrementalDowngradeReason = reason;
-      this.logger.warn(`Incremental route downgraded to full rerender — ${reason}`);
-      return undefined;
-    }
-
-    const unresolved = renderTargets.filter(t => t.resolution !== 'resolved');
-    if (unresolved.length > 0) {
-      const reason = `unresolved-targets: ${unresolved.length}/${renderTargets.length}`;
-      this.lastIncrementalDowngradeReason = reason;
-      this.logger.warn(`Incremental route downgraded to full rerender — ${reason}`);
-      return undefined;
-    }
-
-    this.lastIncrementalDowngradeReason = null;
-    return renderTargets;
-  }
-
   /**
    * キャッシュ短絡を含む経路。`DiffManager` の結果で分岐するが、**コンポーネント単位の増分描画には使わない**。
    */
   async exportWithDiffUpdate(
     dsl: TextUIDSL,
     options: ExportOptions
-  ): Promise<{
-    result: string;
-    isFullUpdate: boolean;
-    changedComponents: number[];
-  }> {
+  ): Promise<ExportWithDiffUpdateResult> {
     return runExportWithDiffUpdate(dsl, options, this.pipelineDeps(), (d, o) =>
       runOptimizedExport(d, o, this.pipelineDeps())
     );
@@ -291,7 +146,7 @@ export class ExportManager {
   clearCache(): void {
     this.cacheManager.clear();
     this.diffManager.reset();
-    this.exportSnapshots.clear();
+    this.snapshotState.clear();
   }
 
   clearFormatCache(format: string): void {
@@ -372,6 +227,6 @@ ${report}
     this.cacheManager.clear();
     this.diffManager.reset();
     this.performanceMonitor.dispose();
-    this.exportSnapshots.clear();
+    this.snapshotState.clear();
   }
 }

--- a/src/exporters/export-observability-recorder.ts
+++ b/src/exporters/export-observability-recorder.ts
@@ -1,0 +1,57 @@
+import { Logger } from '../utils/logger';
+import type {
+  IncrementalRouteFailureKind,
+  IncrementalRouteOutcome,
+  IncrementalRouteTrigger,
+  PerformanceMonitor
+} from '../utils/performance-monitor';
+
+export type IncrementalRouteRecordKind = 'incremental-diff' | 'full-render';
+
+/**
+ * incremental route の downgrade reason とメトリクス記録を集約する。
+ */
+export class ExportObservabilityRecorder {
+  private lastIncrementalDowngradeReasonValue: string | null = null;
+
+  constructor(
+    private readonly performanceMonitor: PerformanceMonitor,
+    private readonly logger: Logger
+  ) {}
+
+  get lastIncrementalDowngradeReason(): string | null {
+    return this.lastIncrementalDowngradeReasonValue;
+  }
+
+  resetIncrementalDowngradeReason(): void {
+    this.lastIncrementalDowngradeReasonValue = null;
+  }
+
+  setLastIncrementalDowngradeReason(reason: string | null): void {
+    this.lastIncrementalDowngradeReasonValue = reason;
+  }
+
+  markIncrementalDowngrade(reason: string): void {
+    this.lastIncrementalDowngradeReasonValue = reason;
+    this.logger.warn(`Incremental route downgraded to full rerender - ${reason}`);
+  }
+
+  recordIncrementalRouteSample(
+    routeKind: IncrementalRouteRecordKind,
+    startedAt: number,
+    payload: {
+      trigger?: IncrementalRouteTrigger;
+      outcome: IncrementalRouteOutcome;
+      failureKind?: IncrementalRouteFailureKind;
+    }
+  ): void {
+    this.performanceMonitor.recordIncrementalRouteSample(
+      routeKind,
+      performance.now() - startedAt,
+      {
+        ...payload,
+        fallbackReason: this.lastIncrementalDowngradeReasonValue
+      }
+    );
+  }
+}

--- a/src/exporters/export-pipeline.ts
+++ b/src/exporters/export-pipeline.ts
@@ -15,6 +15,12 @@ export interface ExportPipelineDeps {
   exporters: Map<string, Exporter>;
 }
 
+export interface ExportWithDiffUpdateResult {
+  result: string;
+  isFullUpdate: boolean;
+  changedComponents: number[];
+}
+
 /**
  * キャッシュ・差分メトリクス付きの 1 回のエクスポート。
  * 差分は観測用（増分レンダーには未使用）。省略は主にキャッシュヒット。
@@ -56,11 +62,7 @@ export async function runExportWithDiffUpdate(
   options: ExportOptions,
   deps: ExportPipelineDeps,
   runOptimized: (d: TextUIDSL, o: ExportOptions) => Promise<string>
-): Promise<{
-  result: string;
-  isFullUpdate: boolean;
-  changedComponents: number[];
-}> {
+): Promise<ExportWithDiffUpdateResult> {
   const diffResult = deps.diffManager.computeDiff(dsl);
 
   if (!diffResult.hasChanges) {

--- a/src/exporters/export-route-policy.ts
+++ b/src/exporters/export-route-policy.ts
@@ -1,0 +1,70 @@
+import type { TextUIDSL } from '../domain/dsl-types';
+import type { DiffRenderTarget } from '../core/textui-core-diff';
+import {
+  buildRenderTargetsFromDiffResult,
+  createDiffResultSkeleton,
+  createNormalizedDiffDocument
+} from '../core/textui-core-diff';
+import type { ExportOptions } from './export-types';
+import type { ExportSnapshotState } from './export-snapshot-state';
+
+export interface IncrementalRouteDecision {
+  shouldAttempt: boolean;
+  renderTargets?: DiffRenderTarget[];
+  downgradeReason?: string;
+}
+
+/**
+ * 増分ルート判定と render target 生成を担当する policy。
+ */
+export class ExportRoutePolicy {
+  constructor(private readonly snapshotState: ExportSnapshotState) {}
+
+  decideIncrementalRoute(dsl: TextUIDSL, options: ExportOptions): IncrementalRouteDecision {
+    const sourcePath = options.sourcePath;
+    if (options.enableIncrementalDiffRoute !== true || !sourcePath) {
+      return { shouldAttempt: false };
+    }
+
+    if (!this.snapshotState.hasSnapshot(sourcePath)) {
+      return { shouldAttempt: false };
+    }
+
+    const previousDsl = this.snapshotState.getSnapshot(sourcePath);
+    if (!previousDsl) {
+      return { shouldAttempt: false };
+    }
+
+    let renderTargets: DiffRenderTarget[];
+    try {
+      const previous = createNormalizedDiffDocument(previousDsl, { side: 'previous', sourcePath });
+      const next = createNormalizedDiffDocument(dsl, { side: 'next', sourcePath });
+      renderTargets = buildRenderTargetsFromDiffResult(createDiffResultSkeleton(previous, next));
+    } catch (error) {
+      return {
+        shouldAttempt: false,
+        downgradeReason: `diff-computation-error: ${error instanceof Error ? error.message : String(error)}`
+      };
+    }
+
+    if (renderTargets.length === 0) {
+      return {
+        shouldAttempt: false,
+        downgradeReason: 'empty-render-targets'
+      };
+    }
+
+    const unresolved = renderTargets.filter(target => target.resolution !== 'resolved');
+    if (unresolved.length > 0) {
+      return {
+        shouldAttempt: false,
+        downgradeReason: `unresolved-targets: ${unresolved.length}/${renderTargets.length}`
+      };
+    }
+
+    return {
+      shouldAttempt: true,
+      renderTargets
+    };
+  }
+}

--- a/src/exporters/export-snapshot-state.ts
+++ b/src/exporters/export-snapshot-state.ts
@@ -1,0 +1,27 @@
+import type { TextUIDSL } from '../domain/dsl-types';
+
+/**
+ * sourcePath ごとの直近 export DSL スナップショットを調停する。
+ */
+export class ExportSnapshotState {
+  private readonly snapshots = new Map<string, TextUIDSL>();
+
+  hasSnapshot(sourcePath: string | undefined): sourcePath is string {
+    return typeof sourcePath === 'string' && sourcePath.length > 0 && this.snapshots.has(sourcePath);
+  }
+
+  getSnapshot(sourcePath: string): TextUIDSL | undefined {
+    return this.snapshots.get(sourcePath);
+  }
+
+  rememberSnapshot(sourcePath: string | undefined, dsl: TextUIDSL): void {
+    if (!sourcePath) {
+      return;
+    }
+    this.snapshots.set(sourcePath, dsl);
+  }
+
+  clear(): void {
+    this.snapshots.clear();
+  }
+}

--- a/tests/unit/export-observability-recorder.test.js
+++ b/tests/unit/export-observability-recorder.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+
+const { PerformanceMonitor } = require('../../out/utils/performance-monitor');
+const { Logger } = require('../../out/utils/logger');
+const { ExportObservabilityRecorder } = require('../../out/exporters/export-observability-recorder');
+
+describe('ExportObservabilityRecorder', () => {
+  beforeEach(() => {
+    const monitor = PerformanceMonitor.getInstance();
+    monitor.dispose();
+    monitor.clear();
+    monitor.forceEnable();
+  });
+
+  it('stores downgrade reason and records fallback sample with reason', () => {
+    const monitor = PerformanceMonitor.getInstance();
+    const recorder = new ExportObservabilityRecorder(monitor, new Logger('ExportObservabilityRecorderTest'));
+
+    recorder.markIncrementalDowngrade('invalid-incremental-result');
+    const startedAt = performance.now() - 5;
+    recorder.recordIncrementalRouteSample('incremental-diff', startedAt, {
+      outcome: 'fallback',
+      failureKind: 'invalid-result'
+    });
+
+    const metrics = monitor.getIncrementalRouteMetrics();
+    assert.strictEqual(recorder.lastIncrementalDowngradeReason, 'invalid-incremental-result');
+    assert.strictEqual(metrics.diffRoute.totalSamples, 1);
+    assert.strictEqual(metrics.diffRoute.fallbackCount, 1);
+    assert.strictEqual(metrics.fallbackReasons['invalid-incremental-result'], 1);
+  });
+
+  it('resets downgrade reason and records success sample without fallback reason', () => {
+    const monitor = PerformanceMonitor.getInstance();
+    const recorder = new ExportObservabilityRecorder(monitor, new Logger('ExportObservabilityRecorderTest'));
+    recorder.markIncrementalDowngrade('temporary-reason');
+    recorder.resetIncrementalDowngradeReason();
+
+    const startedAt = performance.now() - 5;
+    recorder.recordIncrementalRouteSample('incremental-diff', startedAt, {
+      outcome: 'success'
+    });
+
+    const metrics = monitor.getIncrementalRouteMetrics();
+    assert.strictEqual(recorder.lastIncrementalDowngradeReason, null);
+    assert.strictEqual(metrics.diffRoute.totalSamples, 1);
+    assert.strictEqual(metrics.diffRoute.successCount, 1);
+    assert.deepStrictEqual(metrics.fallbackReasons, {});
+  });
+});

--- a/tests/unit/export-route-policy.test.js
+++ b/tests/unit/export-route-policy.test.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+
+const { ExportRoutePolicy } = require('../../out/exporters/export-route-policy');
+const { ExportSnapshotState } = require('../../out/exporters/export-snapshot-state');
+
+describe('ExportRoutePolicy', () => {
+  function createDsl(title) {
+    return {
+      page: {
+        id: 'page-1',
+        title,
+        layout: 'vertical',
+        components: [
+          {
+            Text: {
+              id: 'headline',
+              text: title
+            }
+          }
+        ]
+      }
+    };
+  }
+
+  it('does not attempt incremental route when no previous snapshot exists', () => {
+    const state = new ExportSnapshotState();
+    const policy = new ExportRoutePolicy(state);
+    const nextDsl = createDsl('next');
+
+    const decision = policy.decideIncrementalRoute(nextDsl, {
+      format: 'html',
+      sourcePath: '/tmp/sample.tui.yml',
+      enableIncrementalDiffRoute: true
+    });
+
+    assert.strictEqual(decision.shouldAttempt, false);
+    assert.strictEqual(decision.downgradeReason, undefined);
+  });
+
+  it('builds resolved render targets when incremental route is available', () => {
+    const state = new ExportSnapshotState();
+    const policy = new ExportRoutePolicy(state);
+    const sourcePath = '/tmp/sample.tui.yml';
+    const previousDsl = createDsl('before');
+    const nextDsl = createDsl('after');
+
+    state.rememberSnapshot(sourcePath, previousDsl);
+    const decision = policy.decideIncrementalRoute(nextDsl, {
+      format: 'html',
+      sourcePath,
+      enableIncrementalDiffRoute: true
+    });
+
+    assert.strictEqual(decision.shouldAttempt, true);
+    assert.ok(Array.isArray(decision.renderTargets));
+    assert.ok(decision.renderTargets.length > 0);
+    assert.ok(decision.renderTargets.some(target => target.scope === 'page'));
+    assert.ok(decision.renderTargets.every(target => target.resolution === 'resolved'));
+  });
+
+  it('returns downgrade reason when render targets are empty', () => {
+    const state = new ExportSnapshotState();
+    const policy = new ExportRoutePolicy(state);
+    const sourcePath = '/tmp/sample.tui.yml';
+    const sameDsl = createDsl('same');
+    state.rememberSnapshot(sourcePath, sameDsl);
+
+    const decision = policy.decideIncrementalRoute(sameDsl, {
+      format: 'html',
+      sourcePath,
+      enableIncrementalDiffRoute: true
+    });
+
+    assert.strictEqual(decision.shouldAttempt, false);
+    assert.strictEqual(decision.downgradeReason, 'empty-render-targets');
+  });
+});

--- a/tests/unit/export-route-policy.test.js
+++ b/tests/unit/export-route-policy.test.js
@@ -58,20 +58,27 @@ describe('ExportRoutePolicy', () => {
     assert.ok(decision.renderTargets.every(target => target.resolution === 'resolved'));
   });
 
-  it('returns downgrade reason when render targets are empty', () => {
+  it('returns downgrade reason when diff computation fails', () => {
     const state = new ExportSnapshotState();
     const policy = new ExportRoutePolicy(state);
     const sourcePath = '/tmp/sample.tui.yml';
-    const sameDsl = createDsl('same');
-    state.rememberSnapshot(sourcePath, sameDsl);
+    const invalidPreviousDsl = {
+      page: {
+        id: 'broken-page',
+        title: 'broken',
+        layout: 'vertical'
+      }
+    };
+    const nextDsl = createDsl('next');
+    state.rememberSnapshot(sourcePath, invalidPreviousDsl);
 
-    const decision = policy.decideIncrementalRoute(sameDsl, {
+    const decision = policy.decideIncrementalRoute(nextDsl, {
       format: 'html',
       sourcePath,
       enableIncrementalDiffRoute: true
     });
 
     assert.strictEqual(decision.shouldAttempt, false);
-    assert.strictEqual(decision.downgradeReason, 'empty-render-targets');
+    assert.match(decision.downgradeReason || '', /^diff-computation-error:/);
   });
 });

--- a/tests/unit/export-snapshot-state.test.js
+++ b/tests/unit/export-snapshot-state.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+
+const { ExportSnapshotState } = require('../../out/exporters/export-snapshot-state');
+
+describe('ExportSnapshotState', () => {
+  function createDsl(title) {
+    return {
+      page: {
+        id: 'page-1',
+        title,
+        layout: 'vertical',
+        components: []
+      }
+    };
+  }
+
+  it('stores and retrieves snapshot by sourcePath', () => {
+    const state = new ExportSnapshotState();
+    const sourcePath = '/tmp/sample.tui.yml';
+    const dsl = createDsl('stored');
+
+    state.rememberSnapshot(sourcePath, dsl);
+
+    assert.strictEqual(state.hasSnapshot(sourcePath), true);
+    assert.deepStrictEqual(state.getSnapshot(sourcePath), dsl);
+  });
+
+  it('ignores empty sourcePath and resets snapshots on clear', () => {
+    const state = new ExportSnapshotState();
+    state.rememberSnapshot('', createDsl('ignored'));
+    assert.strictEqual(state.hasSnapshot(''), false);
+
+    const sourcePath = '/tmp/sample.tui.yml';
+    state.rememberSnapshot(sourcePath, createDsl('stored'));
+    assert.strictEqual(state.hasSnapshot(sourcePath), true);
+
+    state.clear();
+    assert.strictEqual(state.hasSnapshot(sourcePath), false);
+    assert.strictEqual(state.getSnapshot(sourcePath), undefined);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Package / contributes (optional)

- manifest / contributes 変更なし。

## 概要

- T-4 対応として `ExportManager` の責務集中を緩和し、内部を `policy / state / observability / orchestration facade` に分離。
- public API (`registerExporter`, `unregisterExporter`, `exportFromFile`, `exportWithDiffUpdate`, `getSupportedFormats` など) は維持。
- incremental downgrade reason / metrics / cache coordination の責務境界を明確化。

---

## 変更内容の種別（該当するものにチェック）

- [x] リファクタ（内部構造の整理、挙動不変）
- [x] テスト追加
- [ ] バグ修正
- [ ] 機能追加
- [ ] ドキュメントのみ
- [ ] CI / ビルドのみ

---

## 影響範囲（要点）

- `src/exporters/export-manager.ts`
- `src/exporters/export-pipeline.ts`
- 新規追加:
  - `src/exporters/export-route-policy.ts`
  - `src/exporters/export-snapshot-state.ts`
  - `src/exporters/export-observability-recorder.ts`
  - `src/exporters/export-execution-facade.ts`
- 新規テスト:
  - `tests/unit/export-route-policy.test.js`
  - `tests/unit/export-snapshot-state.test.js`
  - `tests/unit/export-observability-recorder.test.js`

---

## テスト

- [x] `npm run compile`
- [x] `npm run test:unit -- --grep "export-manager|ExportRoutePolicy|ExportSnapshotState|ExportObservabilityRecorder"`
- [x] `npm run test:unit -- --grep "incremental diff route flag|incremental benchmark scenarios"`
- [x] `npm run test:unit -- --grep "拡張API契約|ExportManager の拡張ポイント"`
- [x] `npm test`

補足:
- `npm test` は 1340 passing / 2 pending を確認。
- 先行して実行した `--grep "export-manager|..."` は正規表現の都合で `ExportManager` タイトルに十分ヒットしなかったため、追加で `incremental diff route flag|incremental benchmark scenarios` と `拡張API契約|ExportManager の拡張ポイント` を再実行して ExportManager 契約を明示検証。

---

## Docs Update Check

- [x] このPRで contributor flow/setup/testing/CI/runtime boundary/canonical contract/operations docs の更新要否を確認した
- [x] ドキュメント更新は不要（内部リファクタで public contract 不変のため）
- [x] owner/review cadence ポリシーを確認した

## CSS SSoT Check

- [x] 対象外（built-in component CSS / export-side CSS 変更なし）

## Fallback-only note

- [x] 対象外（fallback-only 変更ではない）

## SSoT Exception Log

- [x] none
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e63a2cfc-4551-4911-ab19-95fc52cb784e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e63a2cfc-4551-4911-ab19-95fc52cb784e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

