### PR TITLE
T-043 ExportManager分離第2段: facade/composition境界の明確化

### DIFF
--- a/src/exporters/export-manager-composition-root.ts
+++ b/src/exporters/export-manager-composition-root.ts
@@ -1,0 +1,51 @@
+import { ConfigManager } from '../utils/config-manager';
+import { Logger } from '../utils/logger';
+import { PerformanceMonitor } from '../utils/performance-monitor';
+import { ExportObservabilityRecorder } from './export-observability-recorder';
+import { ExportPipelineWiring } from './export-pipeline-wiring';
+import { ExportRoutePolicy } from './export-route-policy';
+import { ExportSnapshotState } from './export-snapshot-state';
+import { ExporterRegistryCoordinator } from './exporter-registry-coordinator';
+
+export interface ExportManagerComposition {
+  registry: ExporterRegistryCoordinator;
+  pipelineWiring: ExportPipelineWiring;
+  performanceMonitor: PerformanceMonitor;
+  maxConcurrentOperations: number;
+  snapshotState: ExportSnapshotState;
+  routePolicy: ExportRoutePolicy;
+  observability: ExportObservabilityRecorder;
+}
+
+/**
+ * ExportManager の内部 wiring をまとめる composition root。
+ */
+export class ExportManagerCompositionRoot {
+  static compose(): ExportManagerComposition {
+    const settings = ConfigManager.getPerformanceSettings();
+    const performanceMonitor = PerformanceMonitor.getInstance();
+    const snapshotState = new ExportSnapshotState();
+    const routePolicy = new ExportRoutePolicy(snapshotState);
+    const observability = new ExportObservabilityRecorder(
+      performanceMonitor,
+      new Logger('ExportManager')
+    );
+    const registry = new ExporterRegistryCoordinator();
+    const pipelineWiring = new ExportPipelineWiring({
+      registry,
+      performanceMonitor,
+      cacheTTL: settings.cacheTTL,
+      cacheMaxSize: 100
+    });
+
+    return {
+      registry,
+      pipelineWiring,
+      performanceMonitor,
+      maxConcurrentOperations: Math.max(1, settings.maxConcurrentOperations || 3),
+      snapshotState,
+      routePolicy,
+      observability
+    };
+  }
+}

--- a/src/exporters/export-manager.ts
+++ b/src/exporters/export-manager.ts
@@ -1,20 +1,15 @@
 import type { NavigationFlowDSL, TextUIDSL } from '../domain/dsl-types';
 import { loadDslWithIncludesFromPath } from '../dsl/load-dsl-with-includes';
-import { CacheManager } from '../utils/cache-manager';
-import { DiffManager } from './metrics/diff-manager';
-import { PerformanceMonitor } from '../utils/performance-monitor';
-import { ConfigManager } from '../utils/config-manager';
+import type { PerformanceMonitor } from '../utils/performance-monitor';
 import type { ExportOptions, Exporter } from './export-types';
-import { populateBuiltInExporters } from './built-in-exporter-registry';
-import type { ExportPipelineDeps, ExportWithDiffUpdateResult } from './export-pipeline';
-import { runExportWithDiffUpdate, runOptimizedExport } from './export-pipeline';
 import { runBatchExport } from './export-batch';
-import { createPerformanceMonitorExportObserver } from './export-metrics-observer';
-import { Logger } from '../utils/logger';
-import { ExportRoutePolicy } from './export-route-policy';
-import { ExportSnapshotState } from './export-snapshot-state';
+import { ExportManagerCompositionRoot } from './export-manager-composition-root';
+import { ExporterRegistryCoordinator } from './exporter-registry-coordinator';
+import { ExportPipelineWiring } from './export-pipeline-wiring';
+import type { ExportPerformanceStats, ExportWithDiffUpdateResult } from './export-pipeline-wiring';
 import { ExportObservabilityRecorder } from './export-observability-recorder';
 import { ExportExecutionFacade } from './export-execution-facade';
+import { ExportSnapshotState } from './export-snapshot-state';
 
 /**
  * ユーザー向けの export 結果を組み立てる **本流**（ファイル読込・形式に応じた `Exporter`・`CacheManager`）と、
@@ -24,9 +19,8 @@ import { ExportExecutionFacade } from './export-execution-facade';
  * - **観測**: `DiffManager` の差分はメトリクス／レポート用（増分レンダーには未使用）。経路は `docs/current/theme-export-rendering/export-instrumentation.md` と `docs/adr/0007-export-diff-purpose.md`。
  */
 export class ExportManager {
-  private exporters: Map<string, Exporter> = new Map();
-  private readonly cacheManager: CacheManager;
-  private readonly diffManager: DiffManager;
+  private readonly registry: ExporterRegistryCoordinator;
+  private readonly pipelineWiring: ExportPipelineWiring;
   private readonly performanceMonitor: PerformanceMonitor;
   private readonly maxConcurrentOperations: number;
   private readonly snapshotState: ExportSnapshotState;
@@ -34,31 +28,21 @@ export class ExportManager {
   private readonly executionFacade: ExportExecutionFacade;
 
   constructor() {
-    populateBuiltInExporters(this.exporters);
-
-    const settings = ConfigManager.getPerformanceSettings();
-    this.maxConcurrentOperations = Math.max(1, settings.maxConcurrentOperations || 3);
-
-    this.cacheManager = new CacheManager({
-      ttl: settings.cacheTTL,
-      maxSize: 100
-    });
-
-    this.diffManager = new DiffManager();
-    this.performanceMonitor = PerformanceMonitor.getInstance();
-    this.snapshotState = new ExportSnapshotState();
-    const routePolicy = new ExportRoutePolicy(this.snapshotState);
-    const logger = new Logger('ExportManager');
-    this.observability = new ExportObservabilityRecorder(this.performanceMonitor, logger);
+    const composition = ExportManagerCompositionRoot.compose();
+    this.registry = composition.registry;
+    this.pipelineWiring = composition.pipelineWiring;
+    this.performanceMonitor = composition.performanceMonitor;
+    this.maxConcurrentOperations = composition.maxConcurrentOperations;
+    this.snapshotState = composition.snapshotState;
+    this.observability = composition.observability;
     this.executionFacade = new ExportExecutionFacade({
-      routePolicy,
+      routePolicy: composition.routePolicy,
       snapshotState: this.snapshotState,
       observability: this.observability,
-      pipelineDeps: () => this.pipelineDeps(),
+      pipelineDeps: () => this.pipelineWiring.createPipelineDeps(),
       runNavigationExporter: (dsl, options) => this.runNavigationExporter(dsl, options),
       exportWithDiffUpdate: (dsl, options) => this.exportWithDiffUpdate(dsl, options)
     });
-
   }
 
   get lastIncrementalDowngradeReason(): string | null {
@@ -69,22 +53,12 @@ export class ExportManager {
     this.observability.setLastIncrementalDowngradeReason(reason);
   }
 
-  private pipelineDeps(): ExportPipelineDeps {
-    return {
-      cacheManager: this.cacheManager,
-      diffManager: this.diffManager,
-      performanceMonitor: this.performanceMonitor,
-      metricsObserver: createPerformanceMonitorExportObserver(this.performanceMonitor),
-      exporters: this.exporters
-    };
-  }
-
   registerExporter(format: string, exporter: Exporter): void {
-    this.exporters.set(format, exporter);
+    this.registry.register(format, exporter);
   }
 
   unregisterExporter(format: string): boolean {
-    return this.exporters.delete(format);
+    return this.registry.unregister(format);
   }
 
   /**
@@ -96,15 +70,11 @@ export class ExportManager {
       try {
         const { dsl } = loadDslWithIncludesFromPath(filePath);
 
-        const exporter = this.exporters.get(options.format);
-        if (!exporter) {
-          throw new Error(`Unsupported export format: ${options.format}`);
-        }
-
         const normalizedOptions: ExportOptions = {
           ...options,
           sourcePath: options.sourcePath ?? filePath
         };
+        this.registry.resolveOrThrow(normalizedOptions.format);
         const result = await this.executionFacade.export(dsl, normalizedOptions);
         this.executionFacade.rememberSnapshotIfPossible(dsl, normalizedOptions.sourcePath);
         return result;
@@ -115,10 +85,7 @@ export class ExportManager {
   }
 
   private async runNavigationExporter(dsl: NavigationFlowDSL, options: ExportOptions): Promise<string> {
-    const exporter = this.exporters.get(options.format);
-    if (!exporter) {
-      throw new Error(`Unsupported export format: ${options.format}`);
-    }
+    const exporter = this.registry.resolveOrThrow(options.format);
     return exporter.export(dsl, options);
   }
 
@@ -129,9 +96,7 @@ export class ExportManager {
     dsl: TextUIDSL,
     options: ExportOptions
   ): Promise<ExportWithDiffUpdateResult> {
-    return runExportWithDiffUpdate(dsl, options, this.pipelineDeps(), (d, o) =>
-      runOptimizedExport(d, o, this.pipelineDeps())
-    );
+    return this.pipelineWiring.exportWithDiffUpdate(dsl, options);
   }
 
   async batchExport(files: Array<{ path: string; options: ExportOptions }>): Promise<Map<string, string>> {
@@ -144,88 +109,34 @@ export class ExportManager {
   }
 
   clearCache(): void {
-    this.cacheManager.clear();
-    this.diffManager.reset();
+    this.pipelineWiring.clearCache();
     this.snapshotState.clear();
   }
 
   clearFormatCache(format: string): void {
-    if (format) {
-      this.cacheManager.clearFormat(format);
-    }
+    this.pipelineWiring.clearFormatCache(format);
   }
 
   /** **観測**用: キャッシュ・直近 diff・集約メトリクスのスナップショット（本流の戻り値ではない）。 */
-  getPerformanceStats(): {
-    cacheStats: { size: number; maxSize: number; hitRate: number };
-    diffStats: { totalChanges: number; changeRate: number; efficiency: number };
-    exportMetrics: {
-      renderTime: number;
-      cacheHitRate: number;
-      diffEfficiency: number;
-      memoryUsage: number;
-      totalOperations: number;
-    };
-    incrementalRouteMetrics: ReturnType<PerformanceMonitor['getIncrementalRouteMetrics']>;
-  } {
-    const cacheStats = this.cacheManager.getStats();
-    const exportMetrics = this.performanceMonitor.getMetrics();
-    const incrementalRouteMetrics = this.performanceMonitor.getIncrementalRouteMetrics();
-
-    const lastDiff = this.diffManager.getLastDiffResult();
-    const diffStats = lastDiff
-      ? this.diffManager.getDiffStats(lastDiff)
-      : { totalChanges: 0, changeRate: 0, efficiency: 100 };
-
-    return {
-      cacheStats,
-      diffStats,
-      exportMetrics,
-      incrementalRouteMetrics
-    };
+  getPerformanceStats(): ExportPerformanceStats {
+    return this.pipelineWiring.getPerformanceStats();
   }
 
   /** 人間可読な **観測**レポート（デバッグ・チューニング用）。 */
   generatePerformanceReport(): string {
-    const stats = this.getPerformanceStats();
-    const report = this.performanceMonitor.generateReport();
-
-    return `
-# 最適化エクスポートマネージャー パフォーマンスレポート
-
-${report}
-
-## キャッシュ統計
-- キャッシュサイズ: ${stats.cacheStats.size}/${stats.cacheStats.maxSize}
-- キャッシュヒット率: ${stats.cacheStats.hitRate.toFixed(1)}%
-
-## 差分更新統計
-- 総変更数: ${stats.diffStats.totalChanges}
-- 変更率: ${stats.diffStats.changeRate.toFixed(1)}%
-- 効率（直近 DSL 比較）: ${stats.diffStats.efficiency.toFixed(1)}%
-- ローリング差分効率（\`exportMetrics.diffEfficiency\`）: ${stats.exportMetrics.diffEfficiency.toFixed(1)}%
-
-> 差分は現状レンダー省略には使わず、上記は観測用。実際の省略は主にキャッシュヒット。
-
-## 最適化効果
-- 平均レンダリング時間: ${stats.exportMetrics.renderTime.toFixed(2)}ms
-- メモリ使用量: ${stats.exportMetrics.memoryUsage.toFixed(2)}MB
-- 総操作数: ${stats.exportMetrics.totalOperations}
-    `.trim();
+    return this.pipelineWiring.generatePerformanceReport();
   }
 
   getSupportedFormats(): string[] {
-    return Array.from(this.exporters.keys());
+    return this.registry.getSupportedFormats();
   }
 
   getFileExtension(format: string): string {
-    const exporter = this.exporters.get(format);
-    return exporter ? exporter.getFileExtension() : '';
+    return this.registry.getFileExtension(format);
   }
 
   dispose(): void {
-    this.cacheManager.clear();
-    this.diffManager.reset();
+    this.pipelineWiring.dispose();
     this.performanceMonitor.dispose();
     this.snapshotState.clear();
   }

--- a/src/exporters/export-pipeline-wiring.ts
+++ b/src/exporters/export-pipeline-wiring.ts
@@ -1,0 +1,131 @@
+import type { TextUIDSL } from '../domain/dsl-types';
+import { CacheManager } from '../utils/cache-manager';
+import type { PerformanceMonitor } from '../utils/performance-monitor';
+import { DiffManager } from './metrics/diff-manager';
+import type { ExportOptions } from './export-types';
+import type { ExportPipelineDeps, ExportWithDiffUpdateResult } from './export-pipeline';
+import { runExportWithDiffUpdate, runOptimizedExport } from './export-pipeline';
+import { createPerformanceMonitorExportObserver } from './export-metrics-observer';
+import type { ExporterRegistryCoordinator } from './exporter-registry-coordinator';
+
+export type { ExportWithDiffUpdateResult } from './export-pipeline';
+
+export interface ExportPerformanceStats {
+  cacheStats: { size: number; maxSize: number; hitRate: number };
+  diffStats: { totalChanges: number; changeRate: number; efficiency: number };
+  exportMetrics: {
+    renderTime: number;
+    cacheHitRate: number;
+    diffEfficiency: number;
+    memoryUsage: number;
+    totalOperations: number;
+  };
+  incrementalRouteMetrics: ReturnType<PerformanceMonitor['getIncrementalRouteMetrics']>;
+}
+
+interface ExportPipelineWiringDeps {
+  registry: ExporterRegistryCoordinator;
+  performanceMonitor: PerformanceMonitor;
+  cacheTTL: number;
+  cacheMaxSize?: number;
+}
+
+/**
+ * cache / diff / metrics を束ねた export pipeline の wiring。
+ */
+export class ExportPipelineWiring {
+  private readonly cacheManager: CacheManager;
+  private readonly diffManager = new DiffManager();
+  private readonly performanceMonitor: PerformanceMonitor;
+  private readonly registry: ExporterRegistryCoordinator;
+
+  constructor(deps: ExportPipelineWiringDeps) {
+    this.registry = deps.registry;
+    this.performanceMonitor = deps.performanceMonitor;
+    this.cacheManager = new CacheManager({
+      ttl: deps.cacheTTL,
+      maxSize: deps.cacheMaxSize ?? 100
+    });
+  }
+
+  createPipelineDeps(): ExportPipelineDeps {
+    return {
+      cacheManager: this.cacheManager,
+      diffManager: this.diffManager,
+      performanceMonitor: this.performanceMonitor,
+      metricsObserver: createPerformanceMonitorExportObserver(this.performanceMonitor),
+      exporters: this.registry.getPipelineExporters()
+    };
+  }
+
+  async exportWithDiffUpdate(
+    dsl: TextUIDSL,
+    options: ExportOptions
+  ): Promise<ExportWithDiffUpdateResult> {
+    return runExportWithDiffUpdate(dsl, options, this.createPipelineDeps(), (targetDsl, targetOptions) =>
+      runOptimizedExport(targetDsl, targetOptions, this.createPipelineDeps())
+    );
+  }
+
+  clearCache(): void {
+    this.cacheManager.clear();
+    this.diffManager.reset();
+  }
+
+  clearFormatCache(format: string): void {
+    if (format) {
+      this.cacheManager.clearFormat(format);
+    }
+  }
+
+  getPerformanceStats(): ExportPerformanceStats {
+    const cacheStats = this.cacheManager.getStats();
+    const exportMetrics = this.performanceMonitor.getMetrics();
+    const incrementalRouteMetrics = this.performanceMonitor.getIncrementalRouteMetrics();
+
+    const lastDiff = this.diffManager.getLastDiffResult();
+    const diffStats = lastDiff
+      ? this.diffManager.getDiffStats(lastDiff)
+      : { totalChanges: 0, changeRate: 0, efficiency: 100 };
+
+    return {
+      cacheStats,
+      diffStats,
+      exportMetrics,
+      incrementalRouteMetrics
+    };
+  }
+
+  generatePerformanceReport(): string {
+    const stats = this.getPerformanceStats();
+    const report = this.performanceMonitor.generateReport();
+
+    return `
+# 最適化エクスポートマネージャー パフォーマンスレポート
+
+${report}
+
+## キャッシュ統計
+- キャッシュサイズ: ${stats.cacheStats.size}/${stats.cacheStats.maxSize}
+- キャッシュヒット率: ${stats.cacheStats.hitRate.toFixed(1)}%
+
+## 差分更新統計
+- 総変更数: ${stats.diffStats.totalChanges}
+- 変更率: ${stats.diffStats.changeRate.toFixed(1)}%
+- 効率（直近 DSL 比較）: ${stats.diffStats.efficiency.toFixed(1)}%
+- ローリング差分効率（\`exportMetrics.diffEfficiency\`）: ${stats.exportMetrics.diffEfficiency.toFixed(1)}%
+
+> 差分は現状レンダー省略には使わず、上記は観測用。実際の省略は主にキャッシュヒット。
+
+## 最適化効果
+- 平均レンダリング時間: ${stats.exportMetrics.renderTime.toFixed(2)}ms
+- メモリ使用量: ${stats.exportMetrics.memoryUsage.toFixed(2)}MB
+- 総操作数: ${stats.exportMetrics.totalOperations}
+    `.trim();
+  }
+
+  dispose(): void {
+    this.cacheManager.clear();
+    this.diffManager.reset();
+  }
+}

--- a/src/exporters/exporter-registry-coordinator.ts
+++ b/src/exporters/exporter-registry-coordinator.ts
@@ -1,0 +1,46 @@
+import { populateBuiltInExporters } from './built-in-exporter-registry';
+import type { Exporter } from './export-types';
+
+/**
+ * Exporter registry の登録・解決を調停する。
+ */
+export class ExporterRegistryCoordinator {
+  private readonly exporters = new Map<string, Exporter>();
+
+  constructor() {
+    populateBuiltInExporters(this.exporters);
+  }
+
+  register(format: string, exporter: Exporter): void {
+    this.exporters.set(format, exporter);
+  }
+
+  unregister(format: string): boolean {
+    return this.exporters.delete(format);
+  }
+
+  resolve(format: string): Exporter | undefined {
+    return this.exporters.get(format);
+  }
+
+  resolveOrThrow(format: string): Exporter {
+    const exporter = this.resolve(format);
+    if (!exporter) {
+      throw new Error(`Unsupported export format: ${format}`);
+    }
+    return exporter;
+  }
+
+  getSupportedFormats(): string[] {
+    return Array.from(this.exporters.keys());
+  }
+
+  getFileExtension(format: string): string {
+    const exporter = this.resolve(format);
+    return exporter ? exporter.getFileExtension() : '';
+  }
+
+  getPipelineExporters(): Map<string, Exporter> {
+    return this.exporters;
+  }
+}

--- a/tests/unit/export-manager-boundary-import-guard.test.js
+++ b/tests/unit/export-manager-boundary-import-guard.test.js
@@ -1,0 +1,45 @@
+/**
+ * T-043: ExportManager facade / wiring 境界の import ガード。
+ */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function read(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
+}
+
+describe('export manager boundary import guard (T-043)', () => {
+  it('ExportManager は cache/diff/monitor/pipeline の実装詳細へ直接依存しない', () => {
+    const managerCode = read('src/exporters/export-manager.ts');
+    const forbiddenImports = [
+      'from \'../utils/cache-manager\'',
+      'from \'./metrics/diff-manager\'',
+      'from \'../utils/config-manager\'',
+      'from \'../utils/logger\'',
+      'from \'./built-in-exporter-registry\'',
+      'from \'./export-metrics-observer\'',
+      'from \'./export-pipeline\''
+    ];
+    const violations = forbiddenImports
+      .filter(token => managerCode.includes(token))
+      .map(token => `src/exporters/export-manager.ts: forbidden import detected -> ${token}`);
+
+    assert.deepStrictEqual(violations, [], `ExportManager facade 境界違反を検知\n${violations.join('\n')}`);
+  });
+
+  it('Composition root が ConfigManager と PerformanceMonitor を組み立てる', () => {
+    const compositionCode = read('src/exporters/export-manager-composition-root.ts');
+    const requiredImports = [
+      'from \'../utils/config-manager\'',
+      'from \'../utils/performance-monitor\''
+    ];
+    const missing = requiredImports
+      .filter(token => !compositionCode.includes(token))
+      .map(token => `src/exporters/export-manager-composition-root.ts: required import missing -> ${token}`);
+
+    assert.deepStrictEqual(missing, [], `ExportManager composition root 契約違反を検知\n${missing.join('\n')}`);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- `ExportManager` を薄い public facade に寄せ、内部 wiring を `ExportManagerCompositionRoot` / `ExportPipelineWiring` / `ExporterRegistryCoordinator` へ分離しました。
- 既存の ExportExecutionFacade / RoutePolicy / Snapshot / Observability との接続点は維持し、挙動互換を維持しています。
- 境界維持のため import guard (`tests/unit/export-manager-boundary-import-guard.test.js`) を追加しました。

## 変更点
- `src/exporters/export-manager.ts`
  - registry / cache-diff-metrics wiring の直接実装を除去。
  - composition root から依存を受け取り、public API だけを提供する facade へ縮退。
- `src/exporters/export-manager-composition-root.ts`（新規）
  - ConfigManager / PerformanceMonitor を含む依存組み立てを集約。
- `src/exporters/export-pipeline-wiring.ts`（新規）
  - cache / diff / metrics / pipeline deps composition を集約。
- `src/exporters/exporter-registry-coordinator.ts`（新規）
  - built-in exporter 登録と registry coordination を集約。
- `tests/unit/export-manager-boundary-import-guard.test.js`（新規）
  - facade 層が実装詳細へ直接依存しないことをガード。

## テスト
- `npm run compile`
- `npx mocha --no-config --require ./tests/setup.js --timeout 10000 --exit tests/unit/export-manager-*.test.js tests/unit/export-manager-boundary-import-guard.test.js tests/unit/export-route-policy.test.js tests/unit/export-snapshot-state.test.js tests/unit/export-observability-recorder.test.js tests/unit/extensibility-extension-api-contract.test.js`

## SSoT Exception Log
- none

## Docs Update Check
- ExportManager の責務境界をコードと import guard で固定する変更であり、既存ドキュメントの契約を破るものではないため、今回はドキュメント更新は不要です。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c01485-6996-4a68-a1f0-9ea61355d057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c01485-6996-4a68-a1f0-9ea61355d057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

