### PR TITLE
ci: align build artifact contract to VSIX (T-050)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
     # docs/current/ci-webview-artifact-strategy-t015.md
 
   build:
-    name: Build Extension
+    name: Build & Package VSIX
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -374,15 +374,11 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    # build-webview is NOT run in this job: media/ artifacts are committed; the packaged
-    # .vsix uses those files. Drift vs sources is enforced by the `webview-media-drift`
-    # CI job (`npm run check:webview-media-drift`). After changing webview sources, run
-    # `npm run build-webview`, commit updated `media/`, and ensure that check passes locally.
-    - name: Build extension
-      run: npm run compile
-    
-    - name: Package extension
-      run: npm run package
+    # Artifact contract (T-050): this job's artifact is the generated `.vsix` from
+    # `npm run package:vsix`. It is a release-candidate package for validation/distribution,
+    # but this workflow does not publish a release automatically.
+    - name: Build and package VSIX
+      run: npm run package:vsix
     
     - name: Upload build artifacts
       if: success()

--- a/docs/current/ci-webview-artifact-strategy-t015.md
+++ b/docs/current/ci-webview-artifact-strategy-t015.md
@@ -15,7 +15,7 @@
 |--------|------|
 | **ローカル / リリース** | ソース変更後は `build-webview` → **`git add media/`** でコミット（T-002 のエラーメッセージと同趣旨） |
 | **CI（`webview-media-drift`）** | checkout → `npm ci` → `check:webview-media-drift`（内部で `build-webview` 実行後に `git diff media/`） |
-| **CI（`build` / VSIX）** | `compile` + `package` のみ。**このジョブでは `build-webview` は再実行しない**（コミット済み `media/` をパッケージが取り込む前提）。`.github/workflows/ci.yml` 内コメント参照。 |
+| **CI（`build` / VSIX）** | `npm run package:vsix` を実行し、**生成した `.vsix` を artifact として upload** する。`package:vsix` 内で `compile` / `package` / `build-webview` を実行した結果を単一成果物に集約する。 |
 | **`package.json`** | `vscode:prepublish` / `package:vsix` は **`build-webview` を含む** → ローカル／release で **ビルド直後の `media/`** が VSIX に入る。 |
 
 ## 2. build-on-CI 方式（検討メモ）
@@ -57,22 +57,28 @@ build-on-CI へ移行する場合に **追加で必要**になりうること:
 
 | 選択肢 | 本スプリントでの判定 |
 |--------|----------------------|
-| **artifact commit を当面維持** | **採用（フェーズ 0）** — T-002 が既に「ソースとコミット済み成果物のズレ」を抑止しており、VSIX パイプライン（`build` ジョブが `build-webview` を再実行しない設計）とも **矛盾なく整合**している。 |
+| **artifact commit を当面維持** | **採用（フェーズ 0）** — T-002 が既に「ソースとコミット済み成果物のズレ」を抑止しており、VSIX パイプライン（`build` ジョブが `package:vsix` で `.vsix` を生成し upload する設計）とも **矛盾なく整合**している。 |
 | **即時廃止（`media/` 非コミット化）** | **非採用** — VSIX・ローカル・CI の **三点の契約を同時に書き換える**必要があり、本チケットの優先度（低）とコストが見合わない。 |
 | **段階移行** | **推奨** — 次フェーズで (1) CI 上の **並行ビルド＋ artifact** の PoC、(2) VSIX が **artifact 経由でも**同じ内容になる検証、(3) 開発者向け手順の一本化、の順で進められる。 |
 
 ### 採用条件（build-on-CI へ進むためのゲート例）
 
-- VSIX を **`build-webview` 非実行ジョブ**だけで組み立てる場合でも、**常に同一バイト列**になる検証が自動化されている。
+- VSIX を **事前生成済み WebView 依存のジョブ**だけで組み立てる場合でも、**常に同一バイト列**になる検証が自動化されている。
 - `media/` 非コミット時の **初回 clone 体験**（必須コマンド 1 本以内推奨）が合意されている。
 - **T-002 の代替**（「コミットとの diff」から「期待ハッシュ」または「artifact 署名」へ）が定義されている。
 
 ### 次スプリントへの入力（PM / Architect 向けメモ）
 
-- **実装スプリント**では、上記ゲートのうち **1 つ**を選び PoC 化する（例: `build` 前ジョブで `build-webview` → artifact upload → `build` が download して `package`、**まだ**リポジトリの `media/` は残す「二重ソース期間」）。
+- **実装スプリント**では、上記ゲートのうち **1 つ**を選び PoC 化する（例: `build` 前ジョブで `build-webview` → artifact upload → `build` が download して `package:vsix`、**まだ**リポジトリの `media/` は残す「二重ソース期間」）。
+
+## 5. T-050 で確定した Artifact 契約（Final Debt Closure）
+
+- CI の `build` job は **`npm run package:vsix` を実行し、生成された `.vsix` のみを upload する**。
+- この artifact は **配布・検証に使えるリリース候補 VSIX** であり、**CI 内で自動公開は行わない**。
+- これにより「実行コマンド」と「artifact upload 対象」の意味論が 1 対 1 で一致する。
 - **T-002 を変える場合**は PM 承認と **移行チケット**を分離する（本ドキュメントでは **無効化しない**）。
 
-## 5. 関連
+## 6. 関連
 
 - `scripts/check-webview-media-drift.cjs`（T-002）
 - `.github/workflows/ci.yml` — `webview-media-drift` / `build` ジョブのコメント


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Package / contributes (optional)

- No `package-contributes/*.json` change.
- No generated `package.json contributes` sync is involved.

## 概要

- `.github/workflows/ci.yml` の `build` job を `Build & Package VSIX` に改名。
- `Package extension` を `npm run package` から `npm run package:vsix` に変更し、artifact upload 対象 `*.vsix` と生成物を一致させた。
- 同ジョブ内に artifact 契約コメント（artifact の意味と release 自動公開しない方針）を明文化。
- `docs/current/ci-webview-artifact-strategy-t015.md` に T-050 確定契約を追記し、CI artifact の意味論を 1 行で説明できるように更新。

## 影響範囲

- CI workflow: `.github/workflows/ci.yml`
- 運用ドキュメント: `docs/current/ci-webview-artifact-strategy-t015.md`

## テスト

- `npm run package:vsix`
  - `package:vsix` 実行完了を確認。
  - `DONE  Packaged: /workspace/textui-designer-0.9.2.vsix` を確認し、CI の upload 対象 `*.vsix` と実生成物が一致することを検証。

## Docs Update Check

- [x] I checked whether this PR changes contributor flow, setup, testing or CI, runtime boundaries, canonical contracts, or operations docs.
- [x] If docs updates are required, I updated the canonical page and the narrow entry or workflow links that point to it.
- [ ] If no docs update is required, I stated the reason explicitly in this PR.
- [x] I used the current owner and review-cadence policy when deciding which page to update.

## SSoT Exception Log

- none
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e9e2d35-ee99-4aa4-b6b2-06c15436fabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e9e2d35-ee99-4aa4-b6b2-06c15436fabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

