### PR TITLE
Add entity_renamed diff event and sort V2 diff records by Design G-2

### DIFF
--- a/src/core/diff/diff-event-layer.ts
+++ b/src/core/diff/diff-event-layer.ts
@@ -29,3 +29,34 @@ export const DIFF_EVENT_LAYER: Readonly<Record<V2DiffEvent, CompareLogicLayer>> 
 export function diffEventLayer(event: V2DiffEvent): CompareLogicLayer {
   return DIFF_EVENT_LAYER[event];
 }
+
+/**
+ * Stable full order for sorting V2DiffRecord arrays (Design G-2).
+ * structure → surface → semantic; ties within a layer use this fixed position.
+ */
+export const DIFF_EVENT_FULL_ORDER: Readonly<Record<V2DiffEvent, number>> = {
+  entity_added: 0,
+  entity_removed: 1,
+  transition_added: 2,
+  transition_removed: 3,
+  component_added: 4,
+  component_removed: 5,
+  entity_renamed: 6,
+  entity_state_changed: 7,
+  transition_edge_changed: 8,
+  component_action_changed: 9,
+  component_availability_changed: 10,
+  component_guard_changed: 11,
+} as const;
+
+/**
+ * Sort a diffs[] array in-place per Design G-2 full order.
+ * Returns a new array; does not mutate the input.
+ */
+export function sortV2DiffRecords<T extends { decision: { diff_event: V2DiffEvent } }>(
+  records: T[]
+): T[] {
+  return [...records].sort(
+    (a, b) => DIFF_EVENT_FULL_ORDER[a.decision.diff_event] - DIFF_EVENT_FULL_ORDER[b.decision.diff_event]
+  );
+}

--- a/src/core/diff/v2-diff-entity-scan.ts
+++ b/src/core/diff/v2-diff-entity-scan.ts
@@ -38,6 +38,17 @@ function makeEntityRecord(
   return { decision: buildV2Decision(event, targetId, confidence, ambiguityReason), explanation: { evidence: resolved } };
 }
 
+function makeRenameRecord(
+  targetId: string,
+  confidence: number,
+  ambiguityReason?: string
+): V2DiffRecord {
+  return {
+    decision: buildV2Decision('entity_renamed', targetId, confidence, ambiguityReason),
+    explanation: { evidence: [] },
+  };
+}
+
 function normalizeEntityStateChangedPredicate(value: unknown): CanonicalPredicate {
   return { fact: 'entity_state', op: 'eq', value };
 }
@@ -156,12 +167,22 @@ export function scanEntityDiffs(
     diffs.push(makeEntityRecord('entity_removed', pair.removedEntityId, pair.confidence, pair.ambiguityReason, []));
     diffs.push(makeEntityRecord('entity_added', pair.addedEntityId, pair.confidence, pair.ambiguityReason, []));
   } else {
+    const entityDiffRecords: V2DiffRecord[] = [];
+
+    if (previous.page.title !== next.page.title) {
+      entityDiffRecords.push(makeRenameRecord(pair.entityId, pair.confidence, pair.ambiguityReason));
+    }
+
     const previousState = readEntityState(previous);
     const nextState = readEntityState(next);
     if (stableStateStringify(previousState) !== stableStateStringify(nextState)) {
+      entityDiffRecords.push(makeStateRecord(pair.entityId, pair.confidence, previousState, nextState, pair.ambiguityReason));
+    }
+
+    if (entityDiffRecords.length > 0) {
       entities.push({
         entity_id: pair.entityId,
-        diffs: [makeStateRecord(pair.entityId, pair.confidence, previousState, nextState, pair.ambiguityReason)],
+        diffs: entityDiffRecords,
         components: [],
       });
     }

--- a/src/core/diff/v2-semantic-diff-provider.ts
+++ b/src/core/diff/v2-semantic-diff-provider.ts
@@ -17,6 +17,7 @@ import { createNormalizedFlowDiffDocument } from './flow-diff';
 import { scanEntityDiffs } from './v2-diff-entity-scan';
 import { scanComponentDiffs } from './v2-diff-component-scan';
 import { scanTransitionDiffs } from './v2-diff-transition-scan';
+import { sortV2DiffRecords } from './diff-event-layer';
 import type { V2EntityDiff } from './diff-v2-types';
 
 export class V2SemanticDiffProvider implements SemanticDiffProvider {
@@ -64,7 +65,23 @@ export class V2SemanticDiffProvider implements SemanticDiffProvider {
       };
     });
 
-    const totalRecords = populatedScreens.reduce((sum, s) => {
+    const sortedScreens = populatedScreens.map(s => {
+      if ('outOfScope' in s) { return s; }
+      return {
+        ...s,
+        diffs: sortV2DiffRecords(s.diffs),
+        entities: s.entities.map(e => ({
+          ...e,
+          diffs: sortV2DiffRecords(e.diffs),
+          components: e.components.map(c => ({
+            ...c,
+            diffs: sortV2DiffRecords(c.diffs),
+          })),
+        })),
+      };
+    });
+
+    const totalRecords = sortedScreens.reduce((sum, s) => {
       if ('outOfScope' in s) { return sum; }
       const screenDiffs = s.diffs.length;
       const entityDiffs = s.entities.reduce((es, e) => es + e.diffs.length, 0);
@@ -76,7 +93,7 @@ export class V2SemanticDiffProvider implements SemanticDiffProvider {
     }, 0);
 
     const v2: DiffCompareResultV2Payload = {
-      screens: populatedScreens,
+      screens: sortedScreens,
       metadata: { schemaVersion: 'v2-compare-logic/v0', totalRecords },
     };
     return { ...result, v2 };

--- a/tests/unit/v2-diff-entity-scan.test.js
+++ b/tests/unit/v2-diff-entity-scan.test.js
@@ -143,4 +143,135 @@ describe('semantic diff v2 entity scan', () => {
       value: { stage: 'published' },
     });
   });
+
+  it('emits entity_renamed when same id but title changes', () => {
+    const previous = makeDoc('previous', { id: 'settings', title: 'Settings' });
+    const next = makeDoc('next', { id: 'settings', title: 'Preferences' });
+
+    const screens = entityScan.scanEntityDiffs(previous, next);
+    const entityDiffs = screens[0].entities;
+
+    assert.strictEqual(entityDiffs.length, 1);
+    assert.strictEqual(entityDiffs[0].entity_id, 'settings');
+    assert.strictEqual(entityDiffs[0].diffs.length, 1);
+    const dec = entityDiffs[0].diffs[0].decision;
+    assert.strictEqual(dec.diff_event, 'entity_renamed');
+    assert.strictEqual(dec.target_id, 'settings');
+    assert.strictEqual(dec.confidence, 1.0);
+    assert.strictEqual(dec.confidence_band, 'high');
+    assert.strictEqual(entityDiffs[0].diffs[0].explanation.evidence.length, 0);
+  });
+
+  it('emits entity_renamed as surface event with empty evidence', () => {
+    const previous = makeDoc('previous', { id: 'dash', title: 'Dashboard' });
+    const next = makeDoc('next', { id: 'dash', title: 'Home' });
+
+    const screens = entityScan.scanEntityDiffs(previous, next);
+    const record = screens[0].entities[0].diffs[0];
+
+    assert.strictEqual(record.decision.diff_event, 'entity_renamed');
+    assert.deepStrictEqual(record.explanation.evidence, []);
+    assert.strictEqual(record.explanation.before_predicate, undefined);
+    assert.strictEqual(record.explanation.after_predicate, undefined);
+  });
+
+  it('emits both entity_renamed and entity_state_changed when title and state both change', () => {
+    const previous = makeDoc('previous', {
+      id: 'cart',
+      title: 'Cart',
+      state: { count: 1 },
+    });
+    const next = makeDoc('next', {
+      id: 'cart',
+      title: 'Basket',
+      state: { count: 3 },
+    });
+
+    const screens = entityScan.scanEntityDiffs(previous, next);
+    const entityDiffs = screens[0].entities[0].diffs;
+
+    assert.strictEqual(entityDiffs.length, 2);
+    assert.strictEqual(entityDiffs[0].decision.diff_event, 'entity_renamed');
+    assert.strictEqual(entityDiffs[1].decision.diff_event, 'entity_state_changed');
+  });
+
+  it('does not emit entity_renamed when title is unchanged', () => {
+    const previous = makeDoc('previous', { id: 'home', title: 'Home', state: { active: true } });
+    const next = makeDoc('next', { id: 'home', title: 'Home', state: { active: false } });
+
+    const screens = entityScan.scanEntityDiffs(previous, next);
+    const diffs = screens[0].entities[0].diffs;
+
+    assert.strictEqual(diffs.length, 1);
+    assert.strictEqual(diffs[0].decision.diff_event, 'entity_state_changed');
+  });
+
+  it('propagates entity_renamed into provider metadata totalRecords', () => {
+    const provider = new providerModule.V2SemanticDiffProvider();
+    const previous = makeDoc('previous', { id: 'profile', title: 'Profile' });
+    const next = makeDoc('next', { id: 'profile', title: 'My Profile' });
+
+    const result = provider.compareStructureDiff(previous, next);
+
+    assert.ok(result.v2);
+    assert.strictEqual(result.v2.metadata.totalRecords, 1);
+    assert.strictEqual(result.v2.screens[0].entities[0].diffs[0].decision.diff_event, 'entity_renamed');
+  });
+});
+
+describe('sortV2DiffRecords (Design G-2)', () => {
+  let diffEventLayer;
+
+  before(() => {
+    diffEventLayer = require('../../out/core/diff/diff-event-layer');
+  });
+
+  it('sorts structure before surface before semantic', () => {
+    const makeRecord = (event) => ({ decision: { diff_event: event } });
+
+    const input = [
+      makeRecord('entity_state_changed'),
+      makeRecord('entity_renamed'),
+      makeRecord('entity_removed'),
+      makeRecord('entity_added'),
+    ];
+
+    const sorted = diffEventLayer.sortV2DiffRecords(input);
+
+    assert.strictEqual(sorted[0].decision.diff_event, 'entity_added');
+    assert.strictEqual(sorted[1].decision.diff_event, 'entity_removed');
+    assert.strictEqual(sorted[2].decision.diff_event, 'entity_renamed');
+    assert.strictEqual(sorted[3].decision.diff_event, 'entity_state_changed');
+  });
+
+  it('places entity_renamed (surface) between structure and semantic events', () => {
+    const makeRecord = (event) => ({ decision: { diff_event: event } });
+
+    const input = [
+      makeRecord('component_action_changed'),
+      makeRecord('entity_renamed'),
+      makeRecord('component_added'),
+    ];
+
+    const sorted = diffEventLayer.sortV2DiffRecords(input);
+
+    assert.strictEqual(sorted[0].decision.diff_event, 'component_added');
+    assert.strictEqual(sorted[1].decision.diff_event, 'entity_renamed');
+    assert.strictEqual(sorted[2].decision.diff_event, 'component_action_changed');
+  });
+
+  it('does not mutate the input array', () => {
+    const makeRecord = (event) => ({ decision: { diff_event: event } });
+    const input = [makeRecord('entity_state_changed'), makeRecord('entity_added')];
+    const original = [...input];
+
+    diffEventLayer.sortV2DiffRecords(input);
+
+    assert.deepStrictEqual(input.map(r => r.decision.diff_event), original.map(r => r.decision.diff_event));
+  });
+
+  it('preserves stable full order for all 12 events', () => {
+    const events = Object.keys(diffEventLayer.DIFF_EVENT_FULL_ORDER);
+    assert.strictEqual(events.length, 12);
+  });
 });


### PR DESCRIPTION
## Summary

This PR implements the `entity_renamed` diff event (Design G-2) and introduces stable sorting for V2 diff records across all layers (structure, surface, semantic).

### Changes

#### 1. New `entity_renamed` diff event
- Added `makeRenameRecord()` helper in `v2-diff-entity-scan.ts` to emit `entity_renamed` when an entity's title changes while its ID remains the same
- The event has empty evidence (surface-level change, no predicate-based reasoning)
- Can coexist with `entity_state_changed` when both title and state change

#### 2. Diff event sorting (Design G-2)
- Added `DIFF_EVENT_FULL_ORDER` constant in `diff-event-layer.ts` defining stable sort order across all 12 diff events:
  - **Structure layer** (0–5): `entity_added`, `entity_removed`, `transition_added`, `transition_removed`, `component_added`, `component_removed`
  - **Surface layer** (6): `entity_renamed`
  - **Semantic layer** (7–11): `entity_state_changed`, `transition_edge_changed`, `component_action_changed`, `component_availability_changed`, `component_guard_changed`
- Added `sortV2DiffRecords()` function that returns a new sorted array without mutating input
- Integrated sorting into `V2SemanticDiffProvider.compareStructureDiff()` to sort diffs at screen, entity, and component levels

### Test Coverage

- 5 new unit tests for `entity_renamed` behavior (title change detection, empty evidence, coexistence with state changes, no false positives)
- 4 new unit tests for `sortV2DiffRecords()` (layer ordering, surface placement, immutability, full order completeness)
- All tests pass; existing tests remain unaffected

### Affected Layers

- `schema` (diff event types)
- `core/diff` (entity scan, diff event layer, semantic diff provider)

## Docs Update Check

- [x] No docs update required. This is an internal diff event implementation following Design G-2 specification.

## SSoT Exception Log

- [x] None

## Test Plan

- Run `npm run test:unit` to verify all unit tests pass, including the 9 new tests for `entity_renamed` and `sortV2DiffRecords()`
- Existing integration tests confirm no regression in diff detection or provider output structure

https://claude.ai/code/session_01AucwbvCKMZfSpUP9oF1Xyq