### PR TITLE
Host boundary: add host-neutral types, preview controller/adapter split, and VS Code bootstrap

### DIFF
--- a/docs/adr/0012-host-boundary-and-preview-adapter-split.md
+++ b/docs/adr/0012-host-boundary-and-preview-adapter-split.md
@@ -1,0 +1,52 @@
+# ADR 0012: Host Boundary と Preview Adapter の分離
+
+- Status: Accepted
+- Date: 2026-04-25
+
+## Context
+
+現行コードでは、サービス契約や実装に `vscode` 型が露出しており、Host 追加（Obsidian）時に横断改修が必要になる。特に `IWebViewManager` の `vscode.WebviewPanel` 露出と、`WebViewManager` の UI Host / File IO 同居が移植コストを高める。
+
+## Decision
+
+1. アプリ層契約から `vscode` 型を段階除去し、`*Like` 中立型に置換する。
+2. Preview 経路を次の2層に分離する。
+   - `PreviewController`（Host 非依存）
+   - `VscodePreviewHost`（VS Code adapter）
+3. 起動/DI は将来的に以下へ整理する。
+   - `bootstrap-vscode`
+   - `createApplicationRuntime`（共通）
+4. テストは adapter contract test を増やし、グローバル require フック依存を増やさない。
+
+## Consequences
+
+### Positive
+- Host 追加時の変更範囲が adapter 層に限定される。
+- Core / App ロジックの再利用性が上がる。
+- 境界違反を静的ガードで検知しやすい。
+
+### Negative
+- 一時的に型変換コード（adapter）が増える。
+- 既存テストの見直しコストが発生する。
+
+## Rollout Plan
+
+- Sprint1: 境界棚卸し・中立型ポリシー・本ADR確定
+- Sprint2: interface 置換と変換層導入
+- Sprint3: Preview adapter 分割と composition root の分離
+- Sprint4: テスト/CI ガード強化
+
+## Alternatives Considered
+
+1. **現状維持（VS Code 専用最適化）**
+   - 却下。Obsidian 展開の都度、横断変更が必要になる。
+2. **全面 rewrite**
+   - 却下。リスク/コストが高く段階移行に不向き。
+
+## References
+
+- `src/types/services.ts`
+- `src/services/webview-manager.ts`
+- `src/services/service-factory.ts`
+- `src/extension.ts`
+- `tests/setup.js`

--- a/docs/current/operations/obsidian-plugin-readiness-priority-list.md
+++ b/docs/current/operations/obsidian-plugin-readiness-priority-list.md
@@ -1,0 +1,142 @@
+# Obsidian プラグイン展開に向けたコードベース整理（優先度付き）
+
+作成日: 2026-04-25
+
+## 目的
+
+TextUI Designer の現行コードベース（VS Code 拡張中心）を、将来的に Obsidian プラグインへ展開しやすい構造へ整理する。
+
+---
+
+## 優先度リスト
+
+### P0（最優先）: Host API 境界の明確化（`vscode` 依存の隔離）
+
+**現状観察**
+- サービス層の公開インターフェース自体が `vscode.*` 型を直接含んでいる（例: `WebviewPanel`, `Disposable`, `TextDocument`, `Uri`, `Completion*`）。
+- `ServiceFactory` が VS Code 前提の実装を直接 new しており、DI の入口はあるが Host 差し替えの単位が粗い。
+
+**なぜ最優先か**
+- Obsidian 対応の最大障壁は Host API 差分。ここを先に抽象化しないと、以降の機能移植がすべて高コスト化する。
+
+**整理方針**
+- `src/types/services.ts` から `vscode` 型を段階的に排除し、`src/platform/host-types.ts`（新設）などの中立型へ置換。
+- `vscode` 固有処理は adapter 層へ寄せる（例: `src/platform/vscode/*`）。
+- 既存サービスは「アプリケーションサービス（Host 中立）」と「Host adapter」に分割。
+
+**完了条件（DoD）**
+- `src/types/services.ts` から `import * as vscode from 'vscode'` が消える。
+- Host 中立インターフェースに対して VS Code / Obsidian adapter がそれぞれ実装可能な形になる。
+
+---
+
+### P1: Composition Root の二重化（VS Code / Obsidian の起動分離）
+
+**現状観察**
+- `src/extension.ts` → `ExtensionLifecycleManager` → `ServiceInitializer/ServiceFactory` という VS Code 前提の起動連鎖。
+- 起動時に VS Code 固有のイベント・通知・WebView 構築が密結合。
+
+**なぜ高優先か**
+- Host 境界を定義しても、起動経路が一つだと実運用で分岐が増え、可読性と保守性が悪化する。
+
+**整理方針**
+- `bootstrap-vscode.ts` と `bootstrap-obsidian.ts`（新設）へ分割。
+- 共有初期化は `createApplicationRuntime({ hostAdapter, featureFlags })` へ集約。
+- `ServiceFactory` は Host neutral factory + Host-specific bindings の 2 層へ再編。
+
+**完了条件（DoD）**
+- VS Code 側エントリが `bootstrap-vscode` を呼ぶだけになる。
+- Obsidian 側の最小起動（コマンド 1 つ + パース検証）が同じ Runtime で動く。
+
+---
+
+### P2: コマンド／設定／マニフェストの宣言モデル統合
+
+**現状観察**
+- `package.json` の `contributes` に VS Code 固有の設定・コマンド・メニュー条件が大量に定義される。
+- コード側のコマンド登録は `CommandManager` / `command-catalog` で整理されているが、Host 非依存な「機能定義」の単一ソースにはなっていない。
+
+**なぜ高優先か**
+- Obsidian は manifest / settings / command 登録方式が異なるため、宣言モデルを共通化しないと二重管理が発生する。
+
+**整理方針**
+- `capabilities`（例: コマンドID、必要入力、UI露出可否、設定キー）を Host 中立 JSON/TS で定義。
+- VS Code `contributes` と Obsidian manifest への変換器を build-time で生成。
+- `check:contributes` 系ガードに「capability SSoT 逸脱検知」を追加。
+
+**完了条件（DoD）**
+- 新規コマンド追加時、編集箇所が capability 定義 1 か所 + 必要な host adapter のみになる。
+
+---
+
+### P3: Preview 実行基盤の Host 非依存化（WebView ハンドリング再設計）
+
+**現状観察**
+- `WebViewManager` が `vscode.WebviewPanel` を直接扱い、テーマ同期・メッセージ配信・ファイル探索を一体で保持。
+- UI 資産（`src/renderer` + `media/`）は再利用可能だが、コンテナ実装が VS Code に固定。
+
+**なぜ中〜高優先か**
+- Obsidian でも Preview は価値中核。ここを中立化すると移植インパクトが最大。
+
+**整理方針**
+- `PreviewHostBridge`（postMessage, mount, theme apply, lifecycle）を定義。
+- `WebViewManager` を `PreviewController`（中立）と `VscodePreviewHost`（adapter）へ分割。
+- ファイルIO (`fs`, `path`) は `FileSystemPort` に抽出。
+
+**完了条件（DoD）**
+- Preview 更新ロジックが Host 非依存テストで動作。
+- VS Code 側は bridge 実装差し替えのみで既存機能を維持。
+
+---
+
+### P4: テスト基盤の「グローバル require フック依存」縮小
+
+**現状観察**
+- `tests/setup.js` で `Module.prototype.require` をフックして `vscode` モジュールを全面モック化。
+- この方式は現行 VS Code 拡張には有効だが、Host 複数化時に副作用範囲が広い。
+
+**なぜ中優先か**
+- 多 Host での回帰検知の信頼性を上げるには、グローバルフックより adapter contract テスト中心へ移行すべき。
+
+**整理方針**
+- 共通テストは Host 中立レイヤのみを対象にし、Host adapter は個別 contract test へ。
+- `tests/setup.js` は最小限の既存互換に残し、新規テストでは依存禁止ルールを強化。
+
+**完了条件（DoD）**
+- 新規主要機能のテストが `Module.prototype.require` フック非依存で成立。
+
+---
+
+### P5: 配布単位の再編（Core ライブラリ化）
+
+**現状観察**
+- `TextUICoreEngine` は比較的 Host 非依存で、CLI/MCP からも再利用されている。
+- 一方で配布単位は単一拡張パッケージ中心。
+
+**なぜ中優先か**
+- Obsidian だけでなく将来の他 Host 展開（web app / CI bot）にも効く投資。
+
+**整理方針**
+- `@textui/core`（DSL 正規化・検証・差分・エクスポート）と `@textui/host-vscode`（拡張連携）相当へ論理分離。
+- まずは monorepo 化ではなく、同一 repo 内サブパッケージ or build target 分離から開始。
+
+**完了条件（DoD）**
+- CLI/MCP/VSCode/Obsidian が同じ core artifact を参照し、Host 固有コードが混入しない。
+
+---
+
+## 先に手を付けると効果が高い「最初の 2 週間」
+
+1. **Host 中立 interface の PoC を 1 本作る**（`IWebViewManager` 周辺）。
+2. **起動経路を `bootstrap-vscode` に寄せる薄いリファクタ**（挙動不変）。
+3. **capability 定義の雛形作成**（既存コマンド 2〜3 個だけ移行）。
+4. **PreviewController の単体テスト雛形**（vscode モック非依存）。
+
+---
+
+## 補足（現状の強み）
+
+- DSL 型の SSoT（`src/domain/dsl-types`）方針が明確で、型境界を守るためのガードテストも充実している。
+- Core Engine はすでに CLI/MCP から利用されており、Host 中立化の足場がある。
+
+このため、最初に Host API 境界の整理（P0/P1）を実施すれば、Obsidian 展開の実装速度は大きく改善できる。

--- a/docs/current/operations/p0-s1-host-neutral-types-policy.md
+++ b/docs/current/operations/p0-s1-host-neutral-types-policy.md
@@ -1,0 +1,54 @@
+# P0-S1-T2: Host 中立型ポリシー（Draft v1）
+
+作成日: 2026-04-25  
+対象スプリント: P0 / Sprint 1
+
+## 目的
+
+`vscode` 固有型をアプリ層契約から排除し、VS Code / Obsidian 双方で実装可能な最小抽象を定義する。
+
+## 設計原則
+
+1. **Application 層は `vscode` を import しない。**
+2. **Host API は adapter 層で終端させる。**
+3. **中立型は「最小に」保つ（過剰抽象を避ける）。**
+4. **戻り値型は Host 依存オブジェクトではなく domain 値を優先する。**
+
+## 中立型（命名案）
+
+- `DisposableLike`: `dispose(): void`
+- `UriLike`: `toString(): string`, `fsPath?: string`
+- `TextDocumentLike`: `uri`, `getText()`, `languageId`, `version`
+- `PositionLike`: `line`, `character`
+- `CancellationTokenLike`: `isCancellationRequested`
+- `CompletionItemLike`: `label`, `kind?`, `detail?`, `insertText?`
+- `ConfigChangeEventLike`: `affectsConfiguration(section: string): boolean`
+- `PreviewPanelHandle`: `postMessage`, `reveal`, `dispose`
+
+## 変換責務
+
+- VS Code adapter が `vscode.*` → `*Like` に変換。
+- Host 非依存サービスは `*Like` のみを受け取る。
+- Obsidian adapter 実装時は同じ `*Like` を満たす。
+
+## 禁止事項（Do / Don't）
+
+### Do
+- `src/services` の Host 非依存部分で `*Like` 型を使う。
+- Host 実装ごとに adapter ファイルを分離する。
+
+### Don't
+- 中立層で `import * as vscode from 'vscode'` を追加しない。
+- `unknown` で逃げる暫定実装を常態化しない。
+- Host イベントオブジェクトを生で横流ししない。
+
+## ガード方針（次スプリント実装）
+
+- ESLint `no-restricted-imports` で中立層からの `vscode` import を禁止。
+- CI に `host-boundary` チェックを追加。
+- PR テンプレに「Host境界逸脱なし」チェック項目を追加。
+
+## 完了条件（Sprint1）
+
+- 命名案と変換責務がレビュー合意されている。
+- P0対象 interface に対して、どの `*Like` を適用するか決まっている。

--- a/docs/current/operations/p0-s1-vscode-boundary-inventory.md
+++ b/docs/current/operations/p0-s1-vscode-boundary-inventory.md
@@ -1,0 +1,66 @@
+# P0-S1-T1: `vscode` 露出 API 棚卸し（Boundary Inventory）
+
+作成日: 2026-04-25  
+対象スプリント: P0 / Sprint 1
+
+## 目的
+
+Obsidian 展開の前提として、`vscode` 依存境界を **Interface / Factory / Entry point** の3層で可視化し、移行優先順位を確定する。
+
+## 対象範囲
+
+- `src/types/services.ts`
+- `src/services/service-factory.ts`
+- `src/extension.ts`
+- `src/services/webview-manager.ts`
+- `tests/setup.js`（テスト基盤の境界）
+
+---
+
+## 1) Interface 境界マトリクス（`src/types/services.ts`）
+
+| Interface | `vscode` 露出 | リスク | 移行方針 | 優先度 |
+|---|---|---|---|---|
+| `IWebViewManager` | `getPanel(): vscode.WebviewPanel` | 高（UI Host 固有型が契約に露出） | `PanelHandle` / `PreviewHostBridge` へ置換。VS Code 側で adapter 実装 | P0 |
+| `ISettingsService` | `startWatching(): vscode.Disposable`, `hasConfigurationChanged(vscode.ConfigurationChangeEvent)` | 高（設定変更イベント差分） | `DisposableLike`, `ConfigChangeEventLike` を中立化 | P0 |
+| `IDiagnosticManager` | `validateAndReportDiagnostics(vscode.TextDocument)`, `clearDiagnosticsForUri(vscode.Uri)` | 高（Document/URI 抽象欠如） | `TextDocumentLike`, `UriLike` を導入し adapter 変換 | P0 |
+| `ICompletionProvider` | `vscode.Position`, `vscode.CancellationToken`, `vscode.Completion*` | 高（補完 API が Host 強依存） | 補完返却型を App domain 値へ寄せ、Host で変換 | P0 |
+| `ISchemaManager` | 直接露出なし | 低 | 現状維持（IO adapter のみ整理） | P1 |
+| `IThemeManager` | 直接露出なし | 低 | 現状維持（必要なら FileSystemPort 経由化） | P1 |
+| `IExportManager` / `IExportService` / `ITemplateService` / `ICommandManager` | 直接露出なし | 低 | 現状維持 | P1 |
+
+---
+
+## 2) Composition Root 境界（`ServiceFactory` / `extension.ts`）
+
+| レイヤ | 観測 | リスク | Sprint1 での決定事項 |
+|---|---|---|---|
+| Entry point (`extension.ts`) | `vscode.ExtensionContext` を直接受け取り lifecycle を駆動 | Host 追加時に分岐集中 | `bootstrap-vscode` 薄型化を次スプリント候補として固定 |
+| ServiceFactory | VS Code 実装を直接 `new` して束ねる | Host ごとの差し替え粒度が粗い | Common runtime + host bindings の2層分割方針を固定 |
+| WebViewManager | `vscode.WebviewPanel` / `fs` / `path` を同居 | UI Host / File IO が混在 | `PreviewController` + `VscodePreviewHost` 分割を固定 |
+
+---
+
+## 3) テスト境界（`tests/setup.js`）
+
+| 観測 | リスク | Sprint1 方針 |
+|---|---|---|
+| `Module.prototype.require` をフックし `vscode` をグローバルモック | 複数 Host 化時に副作用範囲が大きい | 新規テストではグローバル require フック依存を増やさない |
+| `global.vscode` を注入 | 契約テストの粒度が荒くなる | adapter 単位の contract test を別系統化 |
+
+---
+
+## 4) 優先チケット（Sprint2 への受け渡し）
+
+1. `IWebViewManager` から `vscode.WebviewPanel` を除去（最優先）
+2. `ISettingsService` の `Disposable` / `ConfigurationChangeEvent` を中立イベントへ変換
+3. `IDiagnosticManager` / `ICompletionProvider` の Host 型境界を adapter へ移譲
+4. `ServiceFactory` の host binding 分離
+
+---
+
+## 5) Sprint1 完了判定
+
+- Interface 境界の **P0対象が列挙済み**である。
+- 境界ごとに **移行先の中立型名**が確定している。
+- 次スプリントで着手する順序が合意されている。

--- a/src/bootstrap/vscode-bootstrap.ts
+++ b/src/bootstrap/vscode-bootstrap.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import { ExtensionLifecycleManager } from '../services/extension-lifecycle-manager';
+import { Logger } from '../utils/logger';
+import { installUnhandledRejectionLogger } from '../utils/runtime-error-observability';
+
+let lifecycleManager: ExtensionLifecycleManager | undefined;
+const logger = new Logger('VscodeBootstrap');
+installUnhandledRejectionLogger('VscodeBootstrap');
+
+export async function bootstrapVscode(context: vscode.ExtensionContext): Promise<void> {
+  logger.info('アクティベーション開始');
+
+  try {
+    lifecycleManager = new ExtensionLifecycleManager(context);
+    await lifecycleManager.activate();
+    logger.info('アクティベーション完了');
+  } catch (error) {
+    logger.error('アクティベーション中にエラーが発生しました:', error);
+    if (error instanceof Error && error.stack) {
+      logger.error('スタックトレース:', error.stack);
+    }
+    vscode.window.showErrorMessage(`TextUI Designer拡張の初期化に失敗しました: ${error}`);
+    throw error;
+  }
+}
+
+export function teardownVscode(): void {
+  logger.info('非アクティブ化中');
+
+  if (lifecycleManager) {
+    lifecycleManager.deactivate().catch(error => {
+      logger.error('ライフサイクルマネージャーのクリーンアップに失敗しました:', error);
+    });
+    lifecycleManager = undefined;
+  }
+
+  logger.info('非アクティブ化完了');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,40 +1,10 @@
 import * as vscode from 'vscode';
-import { ExtensionLifecycleManager } from './services/extension-lifecycle-manager';
-import { Logger } from './utils/logger';
-import { installUnhandledRejectionLogger } from './utils/runtime-error-observability';
-
-let lifecycleManager: ExtensionLifecycleManager | undefined;
-const logger = new Logger('Extension');
-installUnhandledRejectionLogger('Extension');
+import { bootstrapVscode, teardownVscode } from './bootstrap/vscode-bootstrap';
 
 export async function activate(context: vscode.ExtensionContext) {
-  logger.info('アクティベーション開始');
-
-
-  try {
-    lifecycleManager = new ExtensionLifecycleManager(context);
-    await lifecycleManager.activate();
-    logger.info('アクティベーション完了');
-  } catch (error) {
-    logger.error('アクティベーション中にエラーが発生しました:', error);
-    if (error instanceof Error && error.stack) {
-      logger.error('スタックトレース:', error.stack);
-    }
-    vscode.window.showErrorMessage(`TextUI Designer拡張の初期化に失敗しました: ${error}`);
-    throw error;
-  }
+  await bootstrapVscode(context);
 }
 
 export function deactivate() {
-  logger.info('非アクティブ化中');
-
-
-  if (lifecycleManager) {
-    lifecycleManager.deactivate().catch(error => {
-      logger.error('ライフサイクルマネージャーのクリーンアップに失敗しました:', error);
-    });
-    lifecycleManager = undefined;
-  }
-
-  logger.info('非アクティブ化完了');
+  teardownVscode();
 }

--- a/src/services/common-runtime-factory.ts
+++ b/src/services/common-runtime-factory.ts
@@ -1,0 +1,94 @@
+import { ExportService } from './export-service';
+import { RuntimeInspectionService } from './runtime-inspection-service';
+import { createRuntimeInspectionCommandBindings } from './runtime-inspection-command-bindings';
+import type { RuntimeInspectionCommandBindings } from './runtime-inspection-command-bindings';
+import type {
+  ISchemaManager,
+  IThemeManager,
+  IWebViewManager,
+  IExportManager,
+  IExportService,
+  ITemplateService,
+  ISettingsService,
+  IDiagnosticManager,
+  ICompletionProvider,
+  ICommandManager
+} from '../types';
+
+export interface ServiceFactoryResult {
+  schemaManager: ISchemaManager;
+  themeManager: IThemeManager;
+  webViewManager: IWebViewManager;
+  exportManager: IExportManager;
+  exportService: IExportService;
+  templateService: ITemplateService;
+  settingsService: ISettingsService;
+  diagnosticManager: IDiagnosticManager;
+  completionProvider: ICompletionProvider;
+  commandManager: ICommandManager;
+}
+
+export interface CommonRuntimeBindings {
+  extensionPath: string;
+  createSchemaManager(): ISchemaManager;
+  createThemeManager(): IThemeManager;
+  createWebViewManager(themeManager: IThemeManager, schemaManager: ISchemaManager): IWebViewManager;
+  createExportManager(): IExportManager;
+  createTemplateService(): ITemplateService;
+  createSettingsService(): ISettingsService;
+  createDiagnosticManager(schemaManager: ISchemaManager): IDiagnosticManager;
+  createCompletionProvider(schemaManager: ISchemaManager): ICompletionProvider;
+  createCommandManager(deps: {
+    webViewManager: IWebViewManager;
+    exportService: IExportService;
+    templateService: ITemplateService;
+    settingsService: ISettingsService;
+    schemaManager: ISchemaManager;
+    themeManager?: IThemeManager;
+    runtimeInspection?: RuntimeInspectionCommandBindings;
+  }): ICommandManager;
+}
+
+export function createApplicationRuntime(bindings: CommonRuntimeBindings): ServiceFactoryResult {
+  const schemaManager = bindings.createSchemaManager();
+  const themeManager = bindings.createThemeManager();
+  const webViewManager = bindings.createWebViewManager(themeManager, schemaManager);
+
+  const exportManager = bindings.createExportManager();
+  const exportService: IExportService = new ExportService(exportManager, themeManager, bindings.extensionPath);
+  const templateService = bindings.createTemplateService();
+  const settingsService = bindings.createSettingsService();
+  const diagnosticManager = bindings.createDiagnosticManager(schemaManager);
+  const completionProvider = bindings.createCompletionProvider(schemaManager);
+
+  const runtimeInspectionService = new RuntimeInspectionService();
+  const commandManager = bindings.createCommandManager({
+    webViewManager,
+    exportService,
+    templateService,
+    settingsService,
+    schemaManager,
+    themeManager,
+    runtimeInspection: createRuntimeInspectionCommandBindings(runtimeInspectionService)
+  });
+
+  return {
+    schemaManager,
+    themeManager,
+    webViewManager,
+    exportManager,
+    exportService,
+    templateService,
+    settingsService,
+    diagnosticManager,
+    completionProvider,
+    commandManager
+  };
+}
+
+/**
+ * @deprecated Use createApplicationRuntime instead.
+ */
+export function createCommonRuntime(bindings: CommonRuntimeBindings): ServiceFactoryResult {
+  return createApplicationRuntime(bindings);
+}

--- a/src/services/completion-provider.ts
+++ b/src/services/completion-provider.ts
@@ -4,6 +4,16 @@ import { Logger } from '../utils/logger';
 import { CompletionContextAnalyzer } from './completion-context-analyzer';
 import { CompletionCache } from './completion-cache';
 import { DescriptorCompletionEngine } from './schema-completion-engine';
+import { asVscodeCompletionContext, asVscodePosition, asVscodeTextDocument } from './vscode-host-adapters';
+import type {
+  CancellationTokenLike,
+  CompletionContextLike,
+  CompletionItemLike,
+  CompletionListLike,
+  ICompletionProvider,
+  PositionLike,
+  TextDocumentLike
+} from '../types';
 
 /**
  * 補完プロバイダー（YAML/JSON の IntelliSense）。
@@ -11,7 +21,7 @@ import { DescriptorCompletionEngine } from './schema-completion-engine';
  * 候補の正本は descriptor カタログ（`DescriptorCompletionEngine` → `COMPONENT_DEFINITIONS` / `COMPONENT_PROPERTIES`）。
  * JSON Schema（`SchemaManager`）は補完経路では読み込まない（診断・バリデーション・スキーマ登録は別系統）。
  */
-export class TextUICompletionProvider implements vscode.CompletionItemProvider {
+export class TextUICompletionProvider implements ICompletionProvider {
   private static readonly NAVIGATION_FLOW_PROPERTIES = ['id', 'title', 'entry', 'screens', 'transitions'];
   private static readonly NAVIGATION_SCREEN_PROPERTIES = ['id', 'page', 'title'];
   private static readonly NAVIGATION_TRANSITION_PROPERTIES = ['from', 'to', 'trigger', 'label', 'condition', 'params'];
@@ -76,11 +86,14 @@ export class TextUICompletionProvider implements vscode.CompletionItemProvider {
    * 補完を提供（デバウンス付き）
    */
   async provideCompletionItems(
-    document: vscode.TextDocument,
-    position: vscode.Position,
-    _token: vscode.CancellationToken,
-    context: vscode.CompletionContext
-  ): Promise<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>> {
+    document: TextDocumentLike,
+    position: PositionLike,
+    _token: CancellationTokenLike,
+    context: CompletionContextLike
+  ): Promise<CompletionItemLike[] | CompletionListLike<CompletionItemLike>> {
+    const vsDocument = asVscodeTextDocument(document);
+    const vsPosition = asVscodePosition(position);
+    const vsContext = asVscodeCompletionContext(context);
     // 既存のタイマーをクリア
     if (this.completionTimeout) {
       clearTimeout(this.completionTimeout);
@@ -90,7 +103,7 @@ export class TextUICompletionProvider implements vscode.CompletionItemProvider {
     return new Promise((resolve) => {
       this.completionTimeout = setTimeout(async () => {
         try {
-          const items = await this.generateCompletionItems(document, position, context);
+          const items = await this.generateCompletionItems(vsDocument, vsPosition, vsContext);
           resolve(items);
         } catch (error) {
           this.logger.error('補完処理でエラーが発生しました:', error);

--- a/src/services/diagnostic-manager.ts
+++ b/src/services/diagnostic-manager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import type { ErrorObject } from 'ajv';
 import { TextUIMemoryTracker } from '../utils/textui-memory-tracker';
-import type { ISchemaManager, SchemaDefinition } from '../types';
+import type { IDiagnosticManager, ISchemaManager, SchemaDefinition, TextDocumentLike, UriLike } from '../types';
 import { suggestSimilarKeys } from './diagnostics/key-suggestion';
 import { buildDiagnosticTemplate } from './diagnostics/template-builder';
 import { assembleDiagnosticMarkdownMessage } from './diagnostics/diagnostic-message-assembler';
@@ -16,6 +16,7 @@ import {
 import { getValidationSchemaKind } from './document-kind-resolver';
 import { Logger } from '../utils/logger';
 import { FlowDiagnosticsManager } from './diagnostics/flow-diagnostics-manager';
+import { asVscodeTextDocument, asVscodeUri } from './vscode-host-adapters';
 
 /**
  * DiagnosticManager へ注入可能な依存（ユニットテストのモック差し替え用）
@@ -33,7 +34,7 @@ export type DiagnosticManagerDeps = {
  * 診断管理サービス
  * YAML/JSONファイルのバリデーションとエラー表示を担当
  */
-export class DiagnosticManager {
+export class DiagnosticManager implements IDiagnosticManager {
   private readonly logger = new Logger('DiagnosticManager');
   private diagnosticCollection: vscode.DiagnosticCollection;
   private validationCache: Map<string, DiagnosticCacheEntry> = new Map();
@@ -60,7 +61,7 @@ export class DiagnosticManager {
   /**
    * 診断を実行（デバウンス付き）
    */
-  async validateAndReportDiagnostics(document: vscode.TextDocument): Promise<void> {
+  async validateAndReportDiagnostics(document: TextDocumentLike): Promise<void> {
     this.scheduler.schedule(async () => {
       await this.performDiagnostics(document);
     }, this.DEBOUNCE_DELAY);
@@ -69,7 +70,7 @@ export class DiagnosticManager {
   /**
    * 診断を実行
    */
-  private async performDiagnostics(document: vscode.TextDocument): Promise<void> {
+  private async performDiagnostics(document: TextDocumentLike): Promise<void> {
     const text = document.getText();
     const uri = document.uri.toString();
     
@@ -78,7 +79,7 @@ export class DiagnosticManager {
 
     const cached = this.cacheStore.getFresh(uri, text, this.CACHE_TTL);
     if (cached) {
-      this.diagnosticCollection.set(document.uri, cached.diagnostics);
+      this.diagnosticCollection.set(asVscodeUri(document.uri), cached.diagnostics);
       return;
     }
 
@@ -90,14 +91,14 @@ export class DiagnosticManager {
   /**
    * 実際の検証処理を実行
    */
-  private async performValidation(document: vscode.TextDocument, text: string, schemaKind: ValidationSchemaKind): Promise<void> {
+  private async performValidation(document: TextDocumentLike, text: string, schemaKind: ValidationSchemaKind): Promise<void> {
     const uri = document.uri.toString();
     const now = Date.now();
 
     const cached = this.cacheStore.getFresh(uri, text, this.CACHE_TTL, now);
     if (cached) {
       this.logger.debug('キャッシュされた診断結果を使用');
-      this.diagnosticCollection.set(document.uri, cached.diagnostics);
+      this.diagnosticCollection.set(asVscodeUri(document.uri), cached.diagnostics);
       return;
     }
 
@@ -112,11 +113,11 @@ export class DiagnosticManager {
       );
       diagnostics.push(diag);
     } else if (result.errors && result.schema) {
-      diagnostics = this.createDiagnosticsFromErrors(result.errors, text, document, result.schema);
+      diagnostics = this.createDiagnosticsFromErrors(result.errors, text, asVscodeTextDocument(document), result.schema);
     }
 
     if (schemaKind === 'navigation' && !result.errorMessage) {
-      diagnostics = diagnostics.concat(this.flowDiagnosticsManager.createDiagnostics(document, text));
+      diagnostics = diagnostics.concat(this.flowDiagnosticsManager.createDiagnostics(asVscodeTextDocument(document), text));
     }
 
     const cacheEntry = {
@@ -134,7 +135,7 @@ export class DiagnosticManager {
       diagnosticCount: diagnostics.length
     });
 
-    this.diagnosticCollection.set(document.uri, diagnostics);
+    this.diagnosticCollection.set(asVscodeUri(document.uri), diagnostics);
   }
 
   /**
@@ -228,9 +229,9 @@ export class DiagnosticManager {
   /**
    * 特定のURIの診断をクリア
    */
-  clearDiagnosticsForUri(uri: vscode.Uri): void {
+  clearDiagnosticsForUri(uri: UriLike): void {
     const uriString = uri.toString();
-    this.diagnosticCollection.delete(uri);
+    this.diagnosticCollection.delete(asVscodeUri(uri));
     this.cacheStore.delete(uriString);
     this.cacheStore.clearLegacyKeys(uriString);
   }

--- a/src/services/event-manager.ts
+++ b/src/services/event-manager.ts
@@ -4,6 +4,7 @@ import { ConfigManager } from '../utils/config-manager';
 import { getDocumentKind } from './document-kind-resolver';
 import { Logger } from '../utils/logger';
 import { cursorLineToComponentIndex } from './webview/cursor-to-component';
+import { toVscodeCompletionItemProvider } from './vscode-host-adapters';
 
 /**
  * イベントリスナーの登録・管理
@@ -63,7 +64,7 @@ export class EventManager {
         { language: 'yaml', scheme: 'file' },
         { language: 'yaml', scheme: 'untitled' }
       ],
-      this.services.completionProvider,
+      toVscodeCompletionItemProvider(this.services.completionProvider),
       '-', ':', ' ' // トリガー文字を追加
     );
     

--- a/src/services/preview/node-preview-theme-file-port.ts
+++ b/src/services/preview/node-preview-theme-file-port.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { PreviewThemeFilePort } from './preview-theme-file-port';
+
+export class NodePreviewThemeFilePort implements PreviewThemeFilePort {
+  getDirectoryPath(filePath: string): string {
+    return path.dirname(filePath);
+  }
+
+  resolveThemePathForDirectory(directoryPath: string): string | undefined {
+    for (const themeFileName of ['textui-theme.yml', 'textui-theme.yaml']) {
+      const candidatePath = path.join(directoryPath, themeFileName);
+      if (fs.existsSync(candidatePath)) {
+        return candidatePath;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/services/preview/preview-controller.ts
+++ b/src/services/preview/preview-controller.ts
@@ -1,0 +1,110 @@
+import type { IThemeManager } from '../../types';
+import type { PreviewHost } from './preview-host';
+import type { PreviewMessagePort, PreviewUpdatePort } from './preview-ports';
+import type { PreviewThemeFilePort } from './preview-theme-file-port';
+
+export interface PreviewControllerDeps {
+  previewHost: PreviewHost;
+  updateManager: PreviewUpdatePort;
+  messageHandler: PreviewMessagePort;
+  themeManager?: IThemeManager;
+  themeFilePort?: PreviewThemeFilePort;
+}
+
+/**
+ * Host 非依存の Preview 更新オーケストレーション。
+ */
+export class PreviewController {
+  constructor(private readonly deps: PreviewControllerDeps) {}
+
+  async openPreview(): Promise<void> {
+    await this.deps.previewHost.openPreview(() => this.deps.messageHandler.setupMessageHandler());
+  }
+
+  async updatePreview(forceUpdate: boolean = false): Promise<void> {
+    await this.deps.updateManager.updatePreview(forceUpdate);
+  }
+
+  sendUpdatingSignal(): void {
+    this.deps.messageHandler.sendUpdatingSignal();
+  }
+
+  closePreview(): void {
+    this.deps.previewHost.closePreview();
+  }
+
+  setLastTuiFile(filePath: string, updatePreview: boolean = false): void {
+    const previousFilePath = this.deps.updateManager.getLastTuiFile();
+    this.deps.updateManager.setLastTuiFile(filePath, updatePreview);
+    void this.syncThemeForDslFile(filePath, previousFilePath);
+  }
+
+  getLastTuiFile(): string | undefined {
+    return this.deps.updateManager.getLastTuiFile();
+  }
+
+  applyThemeVariables(css: string): void {
+    this.deps.messageHandler.applyThemeVariables(css);
+  }
+
+  notifyThemeChange(theme: 'light' | 'dark'): void {
+    this.deps.messageHandler.notifyThemeChange(theme);
+  }
+
+  notifyPreviewSettingsChanged(): void {
+    this.deps.messageHandler.sendPreviewSettings();
+  }
+
+  hasPanel(): boolean {
+    return this.deps.previewHost.hasPanel();
+  }
+
+  getPanel() {
+    return this.deps.previewHost.getPanel();
+  }
+
+  dispose(): void {
+    this.deps.updateManager.dispose();
+    this.deps.previewHost.dispose();
+  }
+
+  openDevTools(): void {
+    this.deps.updateManager.openDevTools();
+  }
+
+  async switchTheme(themePath: string): Promise<void> {
+    return await this.deps.messageHandler.switchTheme(themePath);
+  }
+
+  async sendAvailableThemes(): Promise<void> {
+    return await this.deps.messageHandler.sendAvailableThemes();
+  }
+
+  setThemeManager(themeManager: IThemeManager | undefined): void {
+    this.deps.themeManager = themeManager;
+  }
+
+  private async syncThemeForDslFile(filePath: string, previousFilePath?: string): Promise<void> {
+    if (!this.deps.themeManager) {
+      return;
+    }
+
+    if (!this.deps.themeFilePort) {
+      return;
+    }
+
+    const nextFolder = this.deps.themeFilePort.getDirectoryPath(filePath);
+    const previousFolder = previousFilePath
+      ? this.deps.themeFilePort.getDirectoryPath(previousFilePath)
+      : undefined;
+    if (previousFolder === nextFolder) {
+      return;
+    }
+
+    const resolvedThemePath = this.deps.themeFilePort.resolveThemePathForDirectory(nextFolder);
+    this.deps.themeManager.setThemePath(resolvedThemePath);
+    await this.deps.themeManager.loadTheme();
+    this.applyThemeVariables(this.deps.themeManager.generateCSSVariables());
+    await this.sendAvailableThemes();
+  }
+}

--- a/src/services/preview/preview-host.ts
+++ b/src/services/preview/preview-host.ts
@@ -1,0 +1,9 @@
+import type { WebviewPanelLike } from '../../types';
+
+export interface PreviewHost {
+  openPreview(setupMessageHandler: () => void): Promise<void>;
+  closePreview(): void;
+  hasPanel(): boolean;
+  getPanel(): WebviewPanelLike | undefined;
+  dispose(): void;
+}

--- a/src/services/preview/preview-ports.ts
+++ b/src/services/preview/preview-ports.ts
@@ -1,0 +1,17 @@
+export interface PreviewUpdatePort {
+  updatePreview(forceUpdate?: boolean): Promise<void>;
+  setLastTuiFile(filePath: string, updatePreview?: boolean): void;
+  getLastTuiFile(): string | undefined;
+  dispose(): void;
+  openDevTools(): void;
+}
+
+export interface PreviewMessagePort {
+  setupMessageHandler(): void;
+  sendUpdatingSignal(): void;
+  applyThemeVariables(css: string): void;
+  notifyThemeChange(theme: 'light' | 'dark'): void;
+  sendPreviewSettings(): void;
+  switchTheme(themePath: string): Promise<void>;
+  sendAvailableThemes(): Promise<void>;
+}

--- a/src/services/preview/preview-theme-file-port.ts
+++ b/src/services/preview/preview-theme-file-port.ts
@@ -1,0 +1,4 @@
+export interface PreviewThemeFilePort {
+  getDirectoryPath(filePath: string): string;
+  resolveThemePathForDirectory(directoryPath: string): string | undefined;
+}

--- a/src/services/preview/vscode-preview-host.ts
+++ b/src/services/preview/vscode-preview-host.ts
@@ -1,0 +1,36 @@
+import type { WebviewPanelLike } from '../../types';
+import { WebViewLifecycleManager } from '../webview/webview-lifecycle-manager';
+import type { PreviewHost } from './preview-host';
+
+/**
+ * VS Code 固有の Preview Host 実装。
+ */
+export class VscodePreviewHost implements PreviewHost {
+  constructor(private readonly lifecycleManager: WebViewLifecycleManager) {}
+
+  async openPreview(setupMessageHandler: () => void): Promise<void> {
+    if (this.lifecycleManager.hasPanel()) {
+      this.lifecycleManager.revealPanel();
+      return;
+    }
+
+    await this.lifecycleManager.createPreviewPanel();
+    setupMessageHandler();
+  }
+
+  closePreview(): void {
+    this.lifecycleManager.closePanel();
+  }
+
+  hasPanel(): boolean {
+    return this.lifecycleManager.hasPanel();
+  }
+
+  getPanel(): WebviewPanelLike | undefined {
+    return this.lifecycleManager.getPanel();
+  }
+
+  dispose(): void {
+    this.lifecycleManager.dispose();
+  }
+}

--- a/src/services/service-factory.ts
+++ b/src/services/service-factory.ts
@@ -2,40 +2,64 @@ import * as vscode from 'vscode';
 import { SchemaManager } from './schema-manager';
 import { WebViewManager } from './webview-manager';
 import { CommandManager } from './command-manager';
-import { ExportService } from './export-service';
 import { TemplateService } from './template-service';
 import { SettingsService } from './settings-service';
 import { ExportManager } from '../exporters';
 import { ThemeManager } from './theme-manager';
 import { DiagnosticManager } from './diagnostic-manager';
 import { TextUICompletionProvider } from './completion-provider';
-import { RuntimeInspectionService } from './runtime-inspection-service';
-import { createRuntimeInspectionCommandBindings } from './runtime-inspection-command-bindings';
+import {
+  createApplicationRuntime,
+  type ServiceFactoryResult,
+  type CommonRuntimeBindings
+} from './common-runtime-factory';
 import type {
   ISchemaManager,
   IThemeManager,
   IWebViewManager,
   IExportManager,
-  IExportService,
   ITemplateService,
   ISettingsService,
   IDiagnosticManager,
-  ICompletionProvider,
-  ICommandManager
+  ICompletionProvider
 } from '../types';
 import type { ServiceFactoryOverrides } from './service-initializer';
 
-export interface ServiceFactoryResult {
-  schemaManager: ISchemaManager;
-  themeManager: IThemeManager;
-  webViewManager: IWebViewManager;
-  exportManager: IExportManager;
-  exportService: IExportService;
-  templateService: ITemplateService;
-  settingsService: ISettingsService;
-  diagnosticManager: IDiagnosticManager;
-  completionProvider: ICompletionProvider;
-  commandManager: ICommandManager;
+export interface VscodeServiceBindings {
+  context: vscode.ExtensionContext;
+  factoryOverrides: ServiceFactoryOverrides;
+}
+
+export function createVscodeBindings(
+  context: vscode.ExtensionContext,
+  factoryOverrides: ServiceFactoryOverrides
+): CommonRuntimeBindings {
+  const f = factoryOverrides;
+  return {
+    extensionPath: context.extensionPath,
+    createSchemaManager: (): ISchemaManager =>
+      f.createSchemaManager ? f.createSchemaManager(context) : new SchemaManager(context),
+    createThemeManager: (): IThemeManager =>
+      f.createThemeManager ? f.createThemeManager(context) : new ThemeManager(context),
+    createWebViewManager: (themeManager: IThemeManager, schemaManager: ISchemaManager): IWebViewManager =>
+      f.createWebViewManager
+        ? f.createWebViewManager(context, themeManager, schemaManager)
+        : new WebViewManager(context, themeManager, schemaManager),
+    createExportManager: (): IExportManager =>
+      f.createExportManager ? f.createExportManager() : new ExportManager(),
+    createTemplateService: (): ITemplateService =>
+      f.createTemplateService ? f.createTemplateService() : new TemplateService(),
+    createSettingsService: (): ISettingsService =>
+      f.createSettingsService ? f.createSettingsService() : new SettingsService(),
+    createDiagnosticManager: (schemaManager: ISchemaManager): IDiagnosticManager =>
+      f.createDiagnosticManager ? f.createDiagnosticManager(schemaManager) : new DiagnosticManager(schemaManager),
+    createCompletionProvider: (_schemaManager: ISchemaManager): ICompletionProvider =>
+      f.createCompletionProvider ? f.createCompletionProvider(_schemaManager) : new TextUICompletionProvider(),
+    createCommandManager: (deps) =>
+      f.createCommandManager
+        ? f.createCommandManager(context, deps)
+        : new CommandManager(context, deps)
+  };
 }
 
 export class ServiceFactory {
@@ -45,66 +69,8 @@ export class ServiceFactory {
   ) {}
 
   create(): ServiceFactoryResult {
-    const f = this.factoryOverrides;
-
-    const schemaManager: ISchemaManager = f.createSchemaManager
-      ? f.createSchemaManager(this.context)
-      : new SchemaManager(this.context);
-    const themeManager: IThemeManager = f.createThemeManager
-      ? f.createThemeManager(this.context)
-      : new ThemeManager(this.context);
-
-    const webViewManager: IWebViewManager = f.createWebViewManager
-      ? f.createWebViewManager(this.context, themeManager, schemaManager)
-      : new WebViewManager(this.context, themeManager, schemaManager);
-
-    const exportManager: IExportManager = f.createExportManager
-      ? f.createExportManager()
-      : new ExportManager();
-    const exportService: IExportService = new ExportService(exportManager, themeManager, this.context.extensionPath);
-
-    const templateService: ITemplateService = f.createTemplateService
-      ? f.createTemplateService()
-      : new TemplateService();
-
-    const settingsService: ISettingsService = f.createSettingsService
-      ? f.createSettingsService()
-      : new SettingsService();
-
-    const diagnosticManager: IDiagnosticManager = f.createDiagnosticManager
-      ? f.createDiagnosticManager(schemaManager)
-      : new DiagnosticManager(schemaManager);
-
-    const completionProvider: ICompletionProvider = f.createCompletionProvider
-      ? f.createCompletionProvider(schemaManager)
-      : new TextUICompletionProvider();
-
-    const runtimeInspectionService = new RuntimeInspectionService();
-    const commandManagerDependencies = {
-      webViewManager,
-      exportService,
-      templateService,
-      settingsService,
-      schemaManager,
-      themeManager,
-      runtimeInspection: createRuntimeInspectionCommandBindings(runtimeInspectionService)
-    };
-
-    const commandManager: ICommandManager = f.createCommandManager
-      ? f.createCommandManager(this.context, commandManagerDependencies)
-      : new CommandManager(this.context, commandManagerDependencies);
-
-    return {
-      schemaManager,
-      themeManager,
-      webViewManager,
-      exportManager,
-      exportService,
-      templateService,
-      settingsService,
-      diagnosticManager,
-      completionProvider,
-      commandManager
-    };
+    return createApplicationRuntime(
+      createVscodeBindings(this.context, this.factoryOverrides)
+    );
   }
 }

--- a/src/services/settings-service.ts
+++ b/src/services/settings-service.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ConfigManager } from '../utils/config-manager';
 import { ErrorHandler } from '../utils/error-handler';
-import { ISettingsService } from '../types';
+import type { ConfigurationChangeEventLike, DisposableLike, ISettingsService } from '../types';
 import { Logger } from '../utils/logger';
 
 /**
@@ -126,7 +126,7 @@ export class SettingsService implements ISettingsService {
   /**
    * 設定変更の監視を開始
    */
-  startWatching(callback: () => void): vscode.Disposable {
+  startWatching(callback: () => void): DisposableLike {
     return vscode.workspace.onDidChangeConfiguration(event => {
       if (event.affectsConfiguration('textui-designer')) {
         this.logger.info('TextUI Designer設定が変更されました');
@@ -144,7 +144,7 @@ export class SettingsService implements ISettingsService {
   /**
    * 特定の設定が変更されたかどうかをチェック
    */
-  hasConfigurationChanged(event: vscode.ConfigurationChangeEvent): boolean {
+  hasConfigurationChanged(event: ConfigurationChangeEventLike): boolean {
     return event.affectsConfiguration('textui-designer');
   }
 } 

--- a/src/services/vscode-host-adapters.ts
+++ b/src/services/vscode-host-adapters.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+import type {
+  CompletionContextLike,
+  CompletionItemLike,
+  CompletionListLike,
+  ICompletionProvider,
+  PositionLike,
+  TextDocumentLike,
+  UriLike
+} from '../types';
+
+function isCompletionListLike(value: unknown): value is CompletionListLike<CompletionItemLike> {
+  return Boolean(value) && typeof value === 'object' && Array.isArray((value as { items?: unknown }).items);
+}
+
+/**
+ * Host-neutral completion provider を VS Code の CompletionItemProvider へ適合させる。
+ */
+export function toVscodeCompletionItemProvider(provider: ICompletionProvider): vscode.CompletionItemProvider<vscode.CompletionItem> {
+  return {
+    provideCompletionItems: async (document, position, token, context) => {
+      const result = await provider.provideCompletionItems(
+        document,
+        position,
+        token,
+        context as CompletionContextLike
+      );
+
+      if (Array.isArray(result)) {
+        return result as unknown as vscode.CompletionItem[];
+      }
+
+      if (isCompletionListLike(result)) {
+        if (typeof vscode.CompletionList === 'function') {
+          return new vscode.CompletionList(result.items as unknown as vscode.CompletionItem[], result.isIncomplete ?? false);
+        }
+        return {
+          items: result.items as unknown as vscode.CompletionItem[],
+          isIncomplete: result.isIncomplete ?? false
+        } as vscode.CompletionList<vscode.CompletionItem>;
+      }
+
+      return [];
+    }
+  };
+}
+
+export function asVscodeTextDocument(document: TextDocumentLike): vscode.TextDocument {
+  return document as vscode.TextDocument;
+}
+
+export function asVscodePosition(position: PositionLike): vscode.Position {
+  return position as vscode.Position;
+}
+
+export function asVscodeCompletionContext(context: CompletionContextLike): vscode.CompletionContext {
+  return context as vscode.CompletionContext;
+}
+
+export function asVscodeUri(uri: UriLike): vscode.Uri {
+  return uri as vscode.Uri;
+}

--- a/src/services/webview-manager.ts
+++ b/src/services/webview-manager.ts
@@ -1,130 +1,111 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as path from 'path';
 import { WebViewLifecycleManager } from './webview/webview-lifecycle-manager';
 import { WebViewUpdateManager } from './webview/webview-update-manager';
 import { WebViewMessageHandler } from './webview/webview-message-handler';
 import type { YamlSchemaLoader } from './webview/yaml-parser';
 import type { IThemeManager, IWebViewManager } from '../types';
+import { PreviewController } from './preview/preview-controller';
+import { VscodePreviewHost } from './preview/vscode-preview-host';
+import { NodePreviewThemeFilePort } from './preview/node-preview-theme-file-port';
 
 /**
  * WebViewManager（ファサード）
  * 各専用クラスに処理を委譲する
  */
 export class WebViewManager implements IWebViewManager {
-  private lifecycleManager: WebViewLifecycleManager;
-  private updateManager: WebViewUpdateManager;
-  private messageHandler: WebViewMessageHandler;
-  private themeManager: IThemeManager | undefined;
-  private context: vscode.ExtensionContext;
+  updateManager: WebViewUpdateManager;
+  messageHandler: WebViewMessageHandler;
+  private _themeManager: IThemeManager | undefined;
+  private controller: PreviewController;
 
   constructor(context: vscode.ExtensionContext, themeManager?: IThemeManager, schemaLoader?: YamlSchemaLoader) {
-    this.context = context;
-    this.themeManager = themeManager;
-    this.lifecycleManager = new WebViewLifecycleManager(context);
-    this.updateManager = new WebViewUpdateManager(this.lifecycleManager, schemaLoader);
+    const lifecycleManager = new WebViewLifecycleManager(context);
+    this.updateManager = new WebViewUpdateManager(lifecycleManager, schemaLoader);
     this.messageHandler = new WebViewMessageHandler(
       context,
-      this.lifecycleManager,
+      lifecycleManager,
       this.updateManager,
       themeManager
     );
+    const previewHost = new VscodePreviewHost(lifecycleManager);
+    const themeFilePort = new NodePreviewThemeFilePort();
+    this._themeManager = themeManager;
+    this.controller = new PreviewController({
+      previewHost,
+      updateManager: this.updateManager,
+      messageHandler: this.messageHandler,
+      themeManager,
+      themeFilePort
+    });
+  }
+
+  get themeManager(): IThemeManager | undefined {
+    return this._themeManager;
+  }
+
+  set themeManager(themeManager: IThemeManager | undefined) {
+    this._themeManager = themeManager;
+    this.messageHandler.themeManager = themeManager;
+    this.controller.setThemeManager(themeManager);
   }
 
   async openPreview(): Promise<void> {
-    if (this.lifecycleManager.hasPanel()) {
-      this.lifecycleManager.revealPanel();
-    } else {
-      await this.lifecycleManager.createPreviewPanel();
-      this.messageHandler.setupMessageHandler();
-    }
+    await this.controller.openPreview();
   }
 
   async updatePreview(forceUpdate: boolean = false): Promise<void> {
-    await this.updateManager.updatePreview(forceUpdate);
+    await this.controller.updatePreview(forceUpdate);
   }
 
   sendUpdatingSignal(): void {
-    this.messageHandler.sendUpdatingSignal();
+    this.controller.sendUpdatingSignal();
   }
 
   closePreview(): void {
-    this.lifecycleManager.closePanel();
+    this.controller.closePreview();
   }
 
   setLastTuiFile(filePath: string, updatePreview: boolean = false): void {
-    const previousFilePath = this.updateManager.getLastTuiFile();
-    this.updateManager.setLastTuiFile(filePath, updatePreview);
-    void this.syncThemeForDslFile(filePath, previousFilePath);
+    this.controller.setLastTuiFile(filePath, updatePreview);
   }
 
   getLastTuiFile(): string | undefined {
-    return this.updateManager.getLastTuiFile();
+    return this.controller.getLastTuiFile();
   }
 
   applyThemeVariables(css: string): void {
-    this.messageHandler.applyThemeVariables(css);
+    this.controller.applyThemeVariables(css);
   }
 
   notifyThemeChange(theme: 'light' | 'dark'): void {
-    this.messageHandler.notifyThemeChange(theme);
+    this.controller.notifyThemeChange(theme);
   }
 
   notifyPreviewSettingsChanged(): void {
-    this.messageHandler.sendPreviewSettings();
+    this.controller.notifyPreviewSettingsChanged();
   }
 
   hasPanel(): boolean {
-    return this.lifecycleManager.hasPanel();
+    return this.controller.hasPanel();
   }
 
   getPanel(): vscode.WebviewPanel | undefined {
-    return this.lifecycleManager.getPanel();
+    return this.controller.getPanel() as vscode.WebviewPanel | undefined;
   }
 
   dispose(): void {
-    this.updateManager.dispose();
-    this.lifecycleManager.dispose();
+    this.controller.dispose();
   }
 
   openDevTools(): void {
-    this.updateManager.openDevTools();
+    this.controller.openDevTools();
   }
 
   async switchTheme(themePath: string): Promise<void> {
-    return await this.messageHandler.switchTheme(themePath);
+    return await this.controller.switchTheme(themePath);
   }
 
   async sendAvailableThemes(): Promise<void> {
-    return await this.messageHandler.sendAvailableThemes();
-  }
-
-  private async syncThemeForDslFile(filePath: string, previousFilePath?: string): Promise<void> {
-    if (!this.themeManager) {
-      return;
-    }
-
-    const nextFolder = path.dirname(filePath);
-    const previousFolder = previousFilePath ? path.dirname(previousFilePath) : undefined;
-    if (previousFolder === nextFolder) {
-      return;
-    }
-
-    const resolvedThemePath = this.resolveThemePathForDirectory(nextFolder);
-    this.themeManager.setThemePath(resolvedThemePath);
-    await this.themeManager.loadTheme();
-    this.applyThemeVariables(this.themeManager.generateCSSVariables());
-    await this.sendAvailableThemes();
-  }
-
-  private resolveThemePathForDirectory(directoryPath: string): string | undefined {
-    for (const themeFileName of ['textui-theme.yml', 'textui-theme.yaml']) {
-      const candidatePath = path.join(directoryPath, themeFileName);
-      if (fs.existsSync(candidatePath)) {
-        return candidatePath;
-      }
-    }
-
-    return undefined;
+    return await this.controller.sendAvailableThemes();
   }
 }

--- a/src/types/host.ts
+++ b/src/types/host.ts
@@ -1,0 +1,58 @@
+/**
+ * Host-neutral contract surface used by service interfaces.
+ * VS Code / Obsidian adapters should convert concrete host objects to these shapes.
+ */
+export interface DisposableLike {
+  dispose(): void;
+}
+
+export interface UriLike {
+  toString(): string;
+  fsPath?: string;
+}
+
+export interface TextDocumentLike {
+  uri: UriLike;
+  fileName: string;
+  getText(range?: unknown): string;
+}
+
+export interface PositionLike {
+  line: number;
+  character: number;
+}
+
+export interface CancellationTokenLike {
+  isCancellationRequested: boolean;
+}
+
+export interface CompletionContextLike {
+  triggerKind?: number;
+  triggerCharacter?: string;
+}
+
+export interface CompletionItemLike {
+  label: unknown;
+  kind?: unknown;
+  detail?: string;
+  insertText?: unknown;
+}
+
+export interface CompletionListLike<TItem = CompletionItemLike> {
+  items: TItem[];
+  isIncomplete?: boolean;
+}
+
+export interface ConfigurationChangeEventLike {
+  affectsConfiguration(section: string): boolean;
+}
+
+export interface WebviewLike {
+  postMessage(message: unknown): PromiseLike<boolean>;
+}
+
+export interface WebviewPanelLike {
+  readonly webview: WebviewLike;
+  reveal(viewColumn?: unknown, preserveFocus?: boolean): void;
+  dispose(): void;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './schema';
 export * from './services';
+export * from './host';
 export * from './theme';
 export * from './cache';
 export * from './performance';

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -1,6 +1,17 @@
-import * as vscode from 'vscode';
 import type { TextUIDSL } from '../domain/dsl-types';
 import type { SchemaDefinition, SchemaValidationResult } from './schema';
+import type {
+  CancellationTokenLike,
+  CompletionContextLike,
+  CompletionItemLike,
+  CompletionListLike,
+  ConfigurationChangeEventLike,
+  DisposableLike,
+  PositionLike,
+  TextDocumentLike,
+  UriLike,
+  WebviewPanelLike
+} from './host';
 
 export interface ISchemaManager {
   initialize(): Promise<void>;
@@ -37,7 +48,7 @@ export interface IWebViewManager {
   notifyPreviewSettingsChanged(): void;
   dispose(): void;
   hasPanel(): boolean;
-  getPanel(): vscode.WebviewPanel | undefined;
+  getPanel(): WebviewPanelLike | undefined;
   openDevTools(): void;
 }
 
@@ -82,25 +93,25 @@ export interface ISettingsService {
   resetSettings(): Promise<void>;
   showSettings(): Promise<void>;
   showAutoPreviewSetting(): Promise<void>;
-  startWatching(callback: () => void): vscode.Disposable;
-  hasConfigurationChanged(event: vscode.ConfigurationChangeEvent): boolean;
+  startWatching(callback: () => void): DisposableLike;
+  hasConfigurationChanged(event: ConfigurationChangeEventLike): boolean;
 }
 
 export interface IDiagnosticManager {
-  validateAndReportDiagnostics(document: vscode.TextDocument): Promise<void>;
+  validateAndReportDiagnostics(document: TextDocumentLike): Promise<void>;
   clearDiagnostics(): void;
-  clearDiagnosticsForUri(uri: vscode.Uri): void;
+  clearDiagnosticsForUri(uri: UriLike): void;
   clearCache(): void;
   dispose(): void;
 }
 
 export interface ICompletionProvider {
   provideCompletionItems(
-    document: vscode.TextDocument,
-    position: vscode.Position,
-    token: vscode.CancellationToken,
-    context: vscode.CompletionContext
-  ): Promise<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>>;
+    document: TextDocumentLike,
+    position: PositionLike,
+    token: CancellationTokenLike,
+    context: CompletionContextLike
+  ): Promise<CompletionItemLike[] | CompletionListLike<CompletionItemLike>>;
 }
 
 export interface ICommandManager {

--- a/tests/unit/host-boundary-services-contract.test.js
+++ b/tests/unit/host-boundary-services-contract.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('host boundary service contract guards (Sprint 1/2)', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+  it('services contract does not import vscode directly', () => {
+    const source = read('src/types/services.ts');
+    assert.ok(!/from ['"]vscode['"]/.test(source), 'src/types/services.ts must not import vscode directly');
+  });
+
+  it('common runtime factory does not import vscode directly', () => {
+    const source = read('src/services/common-runtime-factory.ts');
+    assert.ok(!/from ['"]vscode['"]/.test(source), 'common-runtime-factory must not import vscode directly');
+    assert.ok(
+      source.includes('export function createApplicationRuntime'),
+      'common-runtime-factory should expose createApplicationRuntime'
+    );
+  });
+
+  it('host neutral shapes are defined in src/types/host.ts', () => {
+    const source = read('src/types/host.ts');
+    for (const name of [
+      'DisposableLike',
+      'UriLike',
+      'TextDocumentLike',
+      'CompletionContextLike',
+      'CompletionItemLike',
+      'CompletionListLike',
+      'WebviewPanelLike'
+    ]) {
+      assert.ok(source.includes(`interface ${name}`), `missing host shape: ${name}`);
+    }
+  });
+
+  it('event manager registers completion provider through adapter', () => {
+    const source = read('src/services/event-manager.ts');
+    assert.ok(
+      source.includes('toVscodeCompletionItemProvider(this.services.completionProvider)'),
+      'EventManager should route completion providers through toVscodeCompletionItemProvider'
+    );
+  });
+});

--- a/tests/unit/preview-controller-boundary.test.js
+++ b/tests/unit/preview-controller-boundary.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('preview controller boundary guard (Sprint 3)', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const source = fs.readFileSync(path.join(repoRoot, 'src/services/preview/preview-controller.ts'), 'utf8');
+
+  it('does not import vscode directly', () => {
+    assert.ok(!/from ['"]vscode['"]/.test(source), 'preview-controller must not import vscode');
+  });
+
+  it('depends on boundary ports, not concrete webview manager classes', () => {
+    assert.ok(source.includes("from './preview-ports'"), 'preview-controller should depend on preview-ports');
+    assert.ok(
+      source.includes("from './preview-theme-file-port'"),
+      'preview-controller should depend on preview-theme-file-port'
+    );
+    assert.ok(!source.includes("webview-message-handler"), 'preview-controller should not import webview-message-handler directly');
+    assert.ok(!source.includes("webview-update-manager"), 'preview-controller should not import webview-update-manager directly');
+    assert.ok(!source.includes("from 'fs'"), 'preview-controller should not import fs directly');
+    assert.ok(!source.includes("from 'path'"), 'preview-controller should not import path directly');
+  });
+});

--- a/tests/unit/vscode-host-adapters.test.js
+++ b/tests/unit/vscode-host-adapters.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const path = require('path');
+
+describe('vscode host adapters', () => {
+  const adaptersPath = path.resolve(__dirname, '../../out/services/vscode-host-adapters.js');
+  const {
+    toVscodeCompletionItemProvider,
+    asVscodeTextDocument,
+    asVscodePosition,
+    asVscodeCompletionContext,
+    asVscodeUri,
+  } = require(adaptersPath);
+
+  it('adapts array completion results into VS Code provider result', async () => {
+    const provider = toVscodeCompletionItemProvider({
+      provideCompletionItems: async () => [{ label: 'Button' }],
+    });
+
+    const result = await provider.provideCompletionItems(
+      { fileName: 'a.tui.yml', uri: { toString: () => 'file://a' }, getText: () => '' },
+      { line: 0, character: 0 },
+      { isCancellationRequested: false },
+      { triggerKind: 1 }
+    );
+
+    assert.ok(Array.isArray(result));
+    assert.strictEqual(result[0].label, 'Button');
+  });
+
+  it('adapts completion-list-like results into vscode.CompletionList', async () => {
+    const provider = toVscodeCompletionItemProvider({
+      provideCompletionItems: async () => ({
+        items: [{ label: 'Text' }],
+        isIncomplete: true,
+      }),
+    });
+
+    const result = await provider.provideCompletionItems(
+      { fileName: 'a.tui.yml', uri: { toString: () => 'file://a' }, getText: () => '' },
+      { line: 0, character: 0 },
+      { isCancellationRequested: false },
+      { triggerKind: 1 }
+    );
+
+    assert.ok(result);
+    assert.ok(Array.isArray(result.items));
+    assert.strictEqual(result.items[0].label, 'Text');
+    assert.strictEqual(result.isIncomplete, true);
+  });
+
+  it('passes through cast helpers for boundary-local conversion', () => {
+    const doc = { fileName: 'a.tui.yml', uri: { toString: () => 'file://a' }, getText: () => '' };
+    const pos = { line: 1, character: 2 };
+    const ctx = { triggerKind: 1, triggerCharacter: ':' };
+    const uri = { toString: () => 'file://a' };
+
+    assert.strictEqual(asVscodeTextDocument(doc), doc);
+    assert.strictEqual(asVscodePosition(pos), pos);
+    assert.strictEqual(asVscodeCompletionContext(ctx), ctx);
+    assert.strictEqual(asVscodeUri(uri), uri);
+  });
+});


### PR DESCRIPTION
### Motivation
- Remove direct `vscode` types from application-layer contracts so host additions (e.g. Obsidian) can be implemented via adapters. 
- Split Preview responsibilities into a host-neutral controller and host-specific adapter to reduce cross-cutting changes and improve reuse. 
- Provide a common runtime bootstrap and adapter contract so composition and tests can target Host-neutral logic rather than global require hooks.

### Description
- Introduce host-neutral shapes in `src/types/host.ts` and re-export them from `src/types/index.ts`, and update service interfaces in `src/types/services.ts` to use `*Like` types. 
- Add adapter helpers in `src/services/vscode-host-adapters.ts` and update `EventManager` to register completion providers through `toVscodeCompletionItemProvider`. 
- Split Preview into `PreviewController` (`src/services/preview/preview-controller.ts`) and a VS Code adapter `VscodePreviewHost` (`src/services/preview/vscode-preview-host.ts`), plus `Preview` ports and `NodePreviewThemeFilePort` for file lookup. 
- Refactor `WebViewManager` to delegate to the `PreviewController` and wire `VscodePreviewHost` + `NodePreviewThemeFilePort`. 
- Add a common runtime factory `createApplicationRuntime` in `src/services/common-runtime-factory.ts` and `createVscodeBindings` in `service-factory.ts`, and simplify `ServiceFactory` to use the shared runtime. 
- Add a lightweight VS Code bootstrap in `src/bootstrap/vscode-bootstrap.ts` and update `src/extension.ts` to call `bootstrapVscode` / `teardownVscode`. 
- Migrate several services to the host-neutral API surface (`completion-provider.ts`, `diagnostic-manager.ts`, `settings-service.ts`) and add boundary conversion points via the adapter file. 
- Add documentation and operational planning ADRs and sprint notes: `docs/adr/0012-host-boundary-and-preview-adapter-split.md` and related operation files. 
- Add unit/contract tests for the new boundary rules and adapters under `tests/unit/` (`host-boundary-services-contract.test.js`, `preview-controller-boundary.test.js`, `vscode-host-adapters.test.js`).

### Testing
- Ran the unit test suite (`npm test`) which executed the new unit/contract tests under `tests/unit/` and all tests passed. 
- Type-check/build was validated with `tsc`/`npm run build` to ensure API changes compile against the new host-neutral types and adapter bindings, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb29f6f44832fb0dd38127fadd0a8)